### PR TITLE
Refactor to prevent mod-lists from accessing FQM schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     <jackson-dataformat-csv.version>2.14.2</jackson-dataformat-csv.version>
     <aws-sdk-java.version>2.19.2</aws-sdk-java.version>
     <folio-s3-client.version>1.1.0-SNAPSHOT</folio-s3-client.version>
+    <awaitility.version>4.2.0</awaitility.version>
 
     <!-- test dependencies -->
     <testcontainers.version>1.17.6</testcontainers.version>
@@ -126,6 +127,11 @@
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-csv</artifactId>
       <version>${jackson-dataformat-csv.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>${awaitility.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/folio/list/configuration/ListAppConfiguration.java
+++ b/src/main/java/org/folio/list/configuration/ListAppConfiguration.java
@@ -2,11 +2,7 @@ package org.folio.list.configuration;
 
 import lombok.RequiredArgsConstructor;
 import org.folio.fql.FqlService;
-import org.folio.fqm.lib.service.FqmMetaDataService;
 import org.folio.fqm.lib.service.FqlValidationService;
-import org.folio.fqm.lib.service.QueryProcessorService;
-import org.folio.fqm.lib.service.QueryResultsSorterService;
-import org.folio.fqm.lib.service.ResultSetService;
 import org.folio.fqm.lib.FQM;
 import org.folio.list.domain.dto.ListConfiguration;
 import org.folio.list.repository.ListContentsRepository;
@@ -15,13 +11,11 @@ import org.folio.list.services.refresh.DataBatchCallback;
 import org.folio.s3.client.FolioS3Client;
 import org.folio.s3.client.S3ClientFactory;
 import org.folio.s3.client.S3ClientProperties;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 
-import javax.sql.DataSource;
 import java.util.function.Supplier;
 
 @Configuration
@@ -30,33 +24,13 @@ public class ListAppConfiguration {
   private final ListExportProperties listExportProperties;
 
   @Bean
-  public QueryProcessorService queryProcessorService(@Qualifier("readerDataSource") DataSource dataSource) {
-    return FQM.queryProcessorService(dataSource);
-  }
-
-  @Bean
-  public ResultSetService resultSetService(@Qualifier("readerDataSource") DataSource dataSource) {
-    return FQM.resultSetService(dataSource);
-  }
-
-  @Bean
   public FqlService fqlService() {
     return new FqlService();
   }
 
   @Bean
-  public FqlValidationService fqlValidationService(@Qualifier("readerDataSource") DataSource dataSource) {
-    return FQM.fqlValidationService(dataSource);
-  }
-
-  @Bean
-  public FqmMetaDataService fqmMetaDataService(@Qualifier("readerDataSource") DataSource dataSource) {
-    return FQM.fqmMetaDataService(dataSource);
-  }
-
-  @Bean
-  public QueryResultsSorterService queryResultsSorterService(@Qualifier("readerDataSource") DataSource dataSource) {
-    return FQM.queryResultsSorterService(dataSource);
+  public FqlValidationService fqlValidationService() {
+    return FQM.fqlValidationService();
   }
 
   @Bean

--- a/src/main/java/org/folio/list/rest/EntityTypeClient.java
+++ b/src/main/java/org/folio/list/rest/EntityTypeClient.java
@@ -1,17 +1,22 @@
 package org.folio.list.rest;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.folio.querytool.domain.dto.EntityType;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 import java.util.UUID;
 
 @FeignClient(name = "entity-types")
-public interface EntityTypeSummaryClient {
+public interface EntityTypeClient {
   @GetMapping("")
   List<EntityTypeSummary> getEntityTypeSummary(@RequestParam List<UUID> ids);
+
+  @GetMapping("/{entityTypeId}")
+  EntityType getEntityType(@RequestHeader UUID entityTypeId);
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   record EntityTypeSummary(UUID id, String label) {}

--- a/src/main/java/org/folio/list/rest/QueryClient.java
+++ b/src/main/java/org/folio/list/rest/QueryClient.java
@@ -1,0 +1,32 @@
+package org.folio.list.rest;
+
+import org.folio.querytool.domain.dto.ContentsRequest;
+import org.folio.querytool.domain.dto.QueryDetails;
+import org.folio.querytool.domain.dto.QueryIdentifier;
+import org.folio.querytool.domain.dto.SubmitQuery;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@FeignClient(name = "query")
+public interface QueryClient {
+
+  @PostMapping("")
+  QueryIdentifier executeQuery(@RequestBody SubmitQuery submitQuery);
+
+  @GetMapping("/{queryId}")
+  QueryDetails getQuery(@RequestHeader UUID queryId);
+
+  @GetMapping("/{queryId}/sortedIds")
+  List<UUID> getSortedIds(@RequestHeader UUID queryId, @RequestParam Integer offset, @RequestParam Integer limit);
+
+  @PostMapping("/contents")
+  List<Map<String, Object>> getContents(@RequestBody ContentsRequest contentsRequest);
+}

--- a/src/main/java/org/folio/list/services/refresh/ListRefreshService.java
+++ b/src/main/java/org/folio/list/services/refresh/ListRefreshService.java
@@ -2,18 +2,23 @@ package org.folio.list.services.refresh;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.folio.fqm.lib.model.FqlQueryWithContext;
-import org.folio.fqm.lib.service.QueryProcessorService;
-import org.folio.fqm.lib.service.QueryResultsSorterService;
+import org.apache.commons.collections4.CollectionUtils;
+import org.awaitility.Awaitility;
 import org.folio.list.domain.ListEntity;
+import org.folio.list.exception.RefreshCancelledException;
+import org.folio.list.rest.QueryClient;
 import org.folio.list.services.AppShutdownService.ShutdownTask;
-import org.folio.spring.FolioExecutionContext;
+import org.folio.querytool.domain.dto.QueryDetails;
+import org.folio.querytool.domain.dto.QueryIdentifier;
+import org.folio.querytool.domain.dto.SubmitQuery;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 @Service
@@ -21,14 +26,14 @@ import java.util.function.Supplier;
 @RequiredArgsConstructor
 public class ListRefreshService {
 
+  private static final int GET_QUERY_TIME_DELAY_SECONDS = 10;
+  private static final int GET_QUERY_TIMEOUT_MINUTES = 30;
   private static final int DEFAULT_BATCH_SIZE = 1000;
 
-  private final QueryProcessorService queryProcessorService;
-  private final FolioExecutionContext executionContext;
-  private final QueryResultsSorterService queryResultsSorterService;
   private final RefreshSuccessCallback refreshSuccessCallback;
   private final RefreshFailedCallback refreshFailedCallback;
   private final Supplier<DataBatchCallback> dataBatchCallbackSupplier;
+  private final QueryClient queryClient;
 
   @Async
   // Long-running method. Running this method within a transaction boundary will hog db connection for
@@ -39,18 +44,12 @@ public class ListRefreshService {
     try (var autoCloseMe = shutdownTask) {
       log.info("Performing async refresh for list {}, refreshId {}", list.getId(),
         list.getInProgressRefreshId().map(UUID::toString).orElse("NONE"));
-      DataBatchCallback dataBatchCallback = dataBatchCallbackSupplier.get();
-      var fqlQueryWithContext = new FqlQueryWithContext(executionContext.getTenantId(),
-        list.getEntityTypeId(),
-        list.getFqlQuery(),
-        true);
-      queryProcessorService.getIdsInBatch(
-        fqlQueryWithContext,
-        DEFAULT_BATCH_SIZE,
-        batch -> dataBatchCallback.accept(list, batch.ids()),
-        recordsCount -> refreshSuccessCallback.accept(list, recordsCount),
-        throwable -> refreshFailedCallback.accept(list, throwable)
-      );
+      SubmitQuery submitQuery = new SubmitQuery()
+        .entityTypeId(list.getEntityTypeId())
+        .fqlQuery(list.getFqlQuery())
+        .fields(list.getFields());
+      QueryIdentifier queryIdentifier = queryClient.executeQuery(submitQuery);
+      waitForQueryCompletion(list, queryIdentifier.getQueryId());
     } catch (Exception exception) {
       log.error("Unexpected error when performing async refresh for list with id " + list.getId()
         + ", refreshId " + (list.getInProgressRefreshId().map(UUID::toString).orElse("NONE")), exception);
@@ -64,19 +63,44 @@ public class ListRefreshService {
     try (var autoCloseMe = shutdownTask) {
       log.info("Performing async sorting for list {}, refreshId {}", list.getId(),
         list.getInProgressRefreshId().map(UUID::toString).orElse("NONE"));
-      DataBatchCallback dataBatchCallback = dataBatchCallbackSupplier.get();
-      queryResultsSorterService.streamSortedIds(
-        executionContext.getTenantId(),
-        queryId,
-        DEFAULT_BATCH_SIZE,
-        batch -> dataBatchCallback.accept(list, batch.ids()),
-        recordsCount -> refreshSuccessCallback.accept(list, recordsCount),
-        throwable -> refreshFailedCallback.accept(list, throwable)
-      );
+      waitForQueryCompletion(list, queryId);
     } catch (Exception exception) {
       log.error("Unexpected error when performing async refresh for list with id " + list.getId()
         + ", refreshId " + (list.getInProgressRefreshId().map(UUID::toString).orElse("NONE")), exception);
       refreshFailedCallback.accept(list, exception);
     }
+  }
+
+  private void waitForQueryCompletion(ListEntity list, UUID queryId) {
+    log.info("Waiting for completion of query {} for list {}", queryId, list.getId());
+    Awaitility.with()
+      .pollInterval(GET_QUERY_TIME_DELAY_SECONDS, TimeUnit.SECONDS)
+      .await()
+      .atMost(GET_QUERY_TIMEOUT_MINUTES, TimeUnit.MINUTES)
+      .until(() -> queryClient.getQuery(queryId).getStatus() != QueryDetails.StatusEnum.IN_PROGRESS);
+    QueryDetails queryDetails = queryClient.getQuery(queryId);
+
+    if (queryDetails.getStatus() == QueryDetails.StatusEnum.SUCCESS) {
+      int resultCount = importQueryResults(list, queryId);
+      refreshSuccessCallback.accept(list, resultCount);
+    } else if (queryDetails.getStatus() == QueryDetails.StatusEnum.FAILED) {
+      refreshFailedCallback.accept(list, new RuntimeException(queryDetails.getFailureReason()));
+    } else if (queryDetails.getStatus() == QueryDetails.StatusEnum.CANCELLED) {
+      refreshFailedCallback.accept(list, new RefreshCancelledException(list));
+    }
+  }
+
+  private int importQueryResults(ListEntity list, UUID queryId) {
+    log.info("Performing async sorting for list {}, refreshId {}", list.getId(),
+      list.getInProgressRefreshId().map(UUID::toString).orElse("NONE"));
+    DataBatchCallback dataBatchCallback = dataBatchCallbackSupplier.get();
+    int offset = 0;
+    List<UUID> ids = queryClient.getSortedIds(queryId, offset, DEFAULT_BATCH_SIZE);
+    while (!CollectionUtils.isEmpty(ids)) {
+      offset += ids.size();
+      dataBatchCallback.accept(list, ids);
+      ids = queryClient.getSortedIds(queryId, offset, DEFAULT_BATCH_SIZE);
+    }
+    return offset;
   }
 }

--- a/src/test/java/org/folio/list/service/ListServiceGetListContentsTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceGetListContentsTest.java
@@ -1,17 +1,18 @@
 package org.folio.list.service;
 
 import org.folio.fql.FqlService;
-import org.folio.fqm.lib.service.ResultSetService;
 import org.folio.list.domain.ListContent;
 import org.folio.list.domain.ListEntity;
 import org.folio.list.domain.ListRefreshDetails;
 import org.folio.list.exception.PrivateListOfAnotherUserException;
 import org.folio.list.repository.ListContentsRepository;
 import org.folio.list.repository.ListRepository;
+import org.folio.list.rest.QueryClient;
 import org.folio.list.services.ListActions;
 import org.folio.list.services.ListService;
 import org.folio.list.services.ListValidationService;
 import org.folio.list.utils.TestDataFixture;
+import org.folio.querytool.domain.dto.ContentsRequest;
 import org.folio.querytool.domain.dto.ResultsetPage;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.data.OffsetRequest;
@@ -40,11 +41,11 @@ class ListServiceGetListContentsTest {
   @Mock
   private ListRepository listRepository;
   @Mock
-  private ResultSetService resultSetService;
-  @Mock
   private ListContentsRepository listContentsRepository;
   @Mock
   private FqlService fqlService;
+  @Mock
+  private QueryClient queryClient;
   @InjectMocks
   private ListService listService;
 
@@ -58,6 +59,9 @@ class ListServiceGetListContentsTest {
     int size = 2;
     int contentVersion = 2;
     List<String> fields = List.of("id", "key1", "key2");
+    ContentsRequest contentsRequest = new ContentsRequest().entityTypeId(entityTypeId)
+      .fields(fields)
+      .ids(contentIds);
     List<Map<String, Object>> expectedList = List.of(
       Map.of("id", contentIds.get(0), "key1", "value1", "key2", "value2"),
       Map.of("id", contentIds.get(1), "key1", "value3", "key2", "value4")
@@ -82,7 +86,7 @@ class ListServiceGetListContentsTest {
     when(executionContext.getTenantId()).thenReturn(tenantId);
     when(listRepository.findById(listId)).thenReturn(Optional.of(expectedEntity));
     when(listContentsRepository.getContents(listId, successRefresh.getId(), new OffsetRequest(offset, size))).thenReturn(listContents);
-    when(resultSetService.getResultSet(tenantId, entityTypeId, fields, contentIds)).thenReturn(expectedList);
+    when(queryClient.getContents(contentsRequest)).thenReturn(expectedList);
     Optional<ResultsetPage> actualContent = listService.getListContents(listId, offset, size);
     assertThat(actualContent).isEqualTo(expectedContent);
   }
@@ -97,6 +101,9 @@ class ListServiceGetListContentsTest {
     int size = 2;
     int contentVersion = 2;
     List<String> fields = new ArrayList<>(List.of("key1", "key2"));
+    ContentsRequest contentsRequest = new ContentsRequest().entityTypeId(entityTypeId)
+      .fields(fields)
+      .ids(contentIds);
     List<Map<String, Object>> expectedList = List.of(
       Map.of("id", contentIds.get(0), "key1", "value1", "key2", "value2"),
       Map.of("id", contentIds.get(1), "key1", "value3", "key2", "value4")
@@ -121,7 +128,7 @@ class ListServiceGetListContentsTest {
     when(executionContext.getTenantId()).thenReturn(tenantId);
     when(listRepository.findById(listId)).thenReturn(Optional.of(expectedEntity));
     when(listContentsRepository.getContents(listId, successRefresh.getId(), new OffsetRequest(offset, size))).thenReturn(listContents);
-    when(resultSetService.getResultSet(tenantId, entityTypeId, List.of("key1", "key2", "id"), contentIds)).thenReturn(expectedList);
+    when(queryClient.getContents(contentsRequest)).thenReturn(expectedList);
     Optional<ResultsetPage> actualContent = listService.getListContents(listId, offset, size);
     assertThat(actualContent).isEqualTo(expectedContent);
   }
@@ -136,6 +143,9 @@ class ListServiceGetListContentsTest {
     int size = 2;
     int contentVersion = 2;
     List<String> fields = List.of();
+    ContentsRequest contentsRequest = new ContentsRequest().entityTypeId(entityTypeId)
+      .fields(List.of("id"))
+      .ids(contentIds);
     List<Map<String, Object>> expectedList = List.of(
       Map.of("id", contentIds.get(0)),
       Map.of("id", contentIds.get(1))
@@ -160,7 +170,7 @@ class ListServiceGetListContentsTest {
     when(executionContext.getTenantId()).thenReturn(tenantId);
     when(listRepository.findById(listId)).thenReturn(Optional.of(expectedEntity));
     when(listContentsRepository.getContents(listId, successRefresh.getId(), new OffsetRequest(offset, size))).thenReturn(listContents);
-    when(resultSetService.getResultSet(tenantId, entityTypeId, List.of("id"), contentIds)).thenReturn(expectedList);
+    when(queryClient.getContents(contentsRequest)).thenReturn(expectedList);
     Optional<ResultsetPage> actualContent = listService.getListContents(listId, offset, size);
     assertThat(actualContent).isEqualTo(expectedContent);
   }
@@ -174,7 +184,10 @@ class ListServiceGetListContentsTest {
     int offset = 0;
     int size = 2;
     int contentVersion = 2;
-    List<String> fields = List.of();
+    List<String> fields = List.of("id");
+    ContentsRequest contentsRequest = new ContentsRequest().entityTypeId(entityTypeId)
+      .fields(fields)
+      .ids(contentIds);
     List<Map<String, Object>> expectedList = List.of(
       Map.of("id", contentIds.get(0)),
       Map.of("id", contentIds.get(1))
@@ -198,7 +211,7 @@ class ListServiceGetListContentsTest {
     when(executionContext.getTenantId()).thenReturn(tenantId);
     when(listRepository.findById(listId)).thenReturn(Optional.of(expectedEntity));
     when(listContentsRepository.getContents(listId, successRefresh.getId(), new OffsetRequest(offset, size))).thenReturn(listContents);
-    when(resultSetService.getResultSet(tenantId, entityTypeId, List.of("id"), contentIds)).thenReturn(expectedList);
+    when(queryClient.getContents(contentsRequest)).thenReturn(expectedList);
     Optional<ResultsetPage> actualContent = listService.getListContents(listId, offset, size);
     assertThat(actualContent).isEqualTo(expectedContent);
   }

--- a/src/test/java/org/folio/list/service/UserFriendlyQueryServiceTest.java
+++ b/src/test/java/org/folio/list/service/UserFriendlyQueryServiceTest.java
@@ -1,12 +1,12 @@
 package org.folio.list.service;
 
 import org.folio.fql.model.*;
-import org.folio.fqm.lib.service.ResultSetService;
+import org.folio.list.rest.QueryClient;
 import org.folio.list.services.UserFriendlyQueryService;
+import org.folio.querytool.domain.dto.ContentsRequest;
 import org.folio.querytool.domain.dto.EntityType;
 import org.folio.querytool.domain.dto.EntityTypeColumn;
 import org.folio.querytool.domain.dto.SourceColumn;
-import org.folio.spring.FolioExecutionContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -26,9 +26,7 @@ class UserFriendlyQueryServiceTest {
   @InjectMocks
   private UserFriendlyQueryService userFriendlyQueryService;
   @Mock
-  private FolioExecutionContext folioExecutionContext;
-  @Mock
-  private ResultSetService resultSetService;
+  private QueryClient queryClient;
 
   @Test
   void shouldGetStringForFqlEqualsConditionWithoutIdColumn() {
@@ -44,19 +42,22 @@ class UserFriendlyQueryServiceTest {
     List<Map<String, Object>> entityContents = List.of(
       Map.of("field1", "some value")
     );
-    String tenantId = "Tenant_01";
     UUID sourceEntityTypeId = UUID.randomUUID();
     UUID value = UUID.randomUUID();
     UUID entityTypeId = UUID.randomUUID();
     List<String> fields = List.of("id", "field1");
+
     SourceColumn sourceColumn = new SourceColumn().entityTypeId(sourceEntityTypeId.toString()).columnName("field1");
     EntityTypeColumn column = new EntityTypeColumn().name("field1");
     EntityTypeColumn column1 = new EntityTypeColumn().name("field2").idColumnName("field1").source(sourceColumn);
     EntityType entityType = new EntityType().id(entityTypeId.toString()).columns(List.of(column, column1));
-
     EqualsCondition equalsCondition = new EqualsCondition("field1", value.toString());
-    when(folioExecutionContext.getTenantId()).thenReturn(tenantId);
-    when(resultSetService.getResultSet(tenantId, sourceEntityTypeId, fields, List.of(UUID.fromString(equalsCondition.value().toString())))).thenReturn(entityContents);
+    List<UUID> ids = List.of(UUID.fromString(equalsCondition.value().toString()));
+    ContentsRequest contentsRequest = new ContentsRequest().entityTypeId(sourceEntityTypeId)
+      .fields(fields)
+      .ids(ids);
+
+    when(queryClient.getContents(contentsRequest)).thenReturn(entityContents);
 
     String expectedEqualsCondition = "field2 == some value";
     String actualEqualsConditions = userFriendlyQueryService.getUserFriendlyQuery(equalsCondition, entityType);
@@ -77,7 +78,6 @@ class UserFriendlyQueryServiceTest {
     List<Map<String, Object>> entityContents = List.of(
       Map.of("field1", "some value")
     );
-    String tenantId = "Tenant_01";
     UUID entityTypeId = UUID.randomUUID();
     UUID sourceEntityTypeId = UUID.randomUUID();
     UUID value = UUID.randomUUID();
@@ -87,10 +87,12 @@ class UserFriendlyQueryServiceTest {
     EntityTypeColumn column1 = new EntityTypeColumn().name("field2").idColumnName("field1").source(sourceColumn);
     EntityType entityType = new EntityType().id(entityTypeId.toString()).columns(List.of(column, column1));
     NotEqualsCondition notEqualsCondition = new NotEqualsCondition("field1", value.toString());
+    List<UUID> ids = List.of(UUID.fromString(notEqualsCondition.value().toString()));
+    ContentsRequest contentsRequest = new ContentsRequest().entityTypeId(sourceEntityTypeId)
+      .fields(fields)
+      .ids(ids);
 
-    when(folioExecutionContext.getTenantId()).thenReturn(tenantId);
-    when(resultSetService.getResultSet(tenantId, sourceEntityTypeId, fields,
-      List.of(UUID.fromString(notEqualsCondition.value().toString())))).thenReturn(entityContents);
+    when(queryClient.getContents(contentsRequest)).thenReturn(entityContents);
 
     String expectedNotEqualsCondition = "field2 != some value";
     String actualNotEqualsConditions = userFriendlyQueryService.getUserFriendlyQuery(notEqualsCondition, entityType);
@@ -112,20 +114,22 @@ class UserFriendlyQueryServiceTest {
       Map.of("field1", "value1"),
       Map.of("field1", "value2")
     );
-    String tenantId = "Tenant_01";
     UUID entityTypeId = UUID.randomUUID();
     UUID sourceEntityTypeId = UUID.randomUUID();
     UUID value1 = UUID.randomUUID();
     UUID value2 = UUID.randomUUID();
+    List<UUID> ids = List.of(value1, value2);
     List<String> fields = List.of("id", "field1");
+    ContentsRequest contentsRequest = new ContentsRequest().entityTypeId(sourceEntityTypeId)
+      .fields(fields)
+      .ids(ids);
     SourceColumn sourceColumn = new SourceColumn().entityTypeId(sourceEntityTypeId.toString()).columnName("field1");
     EntityTypeColumn column = new EntityTypeColumn().name("field1");
     EntityTypeColumn column1 = new EntityTypeColumn().name("field2").idColumnName("field1").source(sourceColumn);
     EntityType entityType = new EntityType().id(entityTypeId.toString()).columns(List.of(column, column1));
     InCondition inCondition = new InCondition("field1", List.of(value1, value2));
 
-    when(folioExecutionContext.getTenantId()).thenReturn(tenantId);
-    when(resultSetService.getResultSet(tenantId, sourceEntityTypeId, fields, List.of(value1, value2))).thenReturn(entityContents);
+    when(queryClient.getContents(contentsRequest)).thenReturn(entityContents);
 
     String expectedInCondition = "field2 in [value1, value2]";
     String actualInConditions = userFriendlyQueryService.getUserFriendlyQuery(inCondition, entityType);
@@ -147,20 +151,22 @@ class UserFriendlyQueryServiceTest {
       Map.of("field1", "value1"),
       Map.of("field1", "value2")
     );
-    String tenantId = "Tenant_01";
     UUID entityTypeId = UUID.randomUUID();
     UUID sourceEntityTypeId = UUID.randomUUID();
     UUID value1 = UUID.randomUUID();
     UUID value2 = UUID.randomUUID();
+    List<UUID> ids = List.of(value1, value2);
     List<String> fields = List.of("id", "field1");
+    ContentsRequest contentsRequest = new ContentsRequest().entityTypeId(sourceEntityTypeId)
+      .fields(fields)
+      .ids(ids);
     SourceColumn sourceColumn = new SourceColumn().entityTypeId(sourceEntityTypeId.toString()).columnName("field1");
     EntityTypeColumn column = new EntityTypeColumn().name("field1");
     EntityTypeColumn column1 = new EntityTypeColumn().name("field2").idColumnName("field1").source(sourceColumn);
     EntityType entityType = new EntityType().id(entityTypeId.toString()).columns(List.of(column, column1));
     NotInCondition notInCondition = new NotInCondition("field1", List.of(value1, value2));
 
-    when(folioExecutionContext.getTenantId()).thenReturn(tenantId);
-    when(resultSetService.getResultSet(tenantId, sourceEntityTypeId, fields, List.of(value1, value2))).thenReturn(entityContents);
+    when(queryClient.getContents(contentsRequest)).thenReturn(entityContents);
 
     String expectedNotInCondition = "field2 not in [value1, value2]";
     String actualNotInCondition = userFriendlyQueryService.getUserFriendlyQuery(notInCondition, entityType);


### PR DESCRIPTION
## Purpose
mod-lists: Use the FQM API instead of going to its DB schema

## Testing
- [x] All unit tests passed
- [x] List refreshes and exports work with the new APIs