### PR TITLE
MODLISTS-2 Rename "_private" param in ListController

### DIFF
--- a/src/main/java/org/folio/list/controller/ListController.java
+++ b/src/main/java/org/folio/list/controller/ListController.java
@@ -15,14 +15,13 @@ import org.folio.spring.data.OffsetRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.UUID;
-
-import static org.springframework.util.StringUtils.hasText;
 
 @RequiredArgsConstructor
 @RestController
@@ -31,15 +30,19 @@ public class ListController implements ListApi {
   private final ListService listService;
 
   @Override
-  public ResponseEntity<ListSummaryResultsDTO> getAllLists(List<UUID> ids, List<UUID> entityTypeIds, Integer offset,
-                                                           Integer size, Boolean active, Boolean _private, String updatedAsOf
+  public ResponseEntity<ListSummaryResultsDTO> getAllLists(List<UUID> ids,
+                                                           List<UUID> entityTypeIds,
+                                                           Integer offset,
+                                                           Integer size, Boolean active,
+                                                           Boolean isPrivate, // Note: query param name is "private"
+                                                           String updatedAsOf
   ) {
     OffsetDateTime providedTimestamp;
     DateTimeFormatter formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
     // In the backend, the plus sign (+) that is received through RequestParams within the provided timestamp gets substituted with a blank space.
-    providedTimestamp = !hasText(updatedAsOf) ? null : OffsetDateTime.parse(updatedAsOf.replace(' ', '+'), formatter);
+    providedTimestamp = !StringUtils.hasText(updatedAsOf) ? null : OffsetDateTime.parse(updatedAsOf.replace(' ', '+'), formatter);
     Pageable pageable = new OffsetRequest(offset, size);
-    return ResponseEntity.ok(listService.getAllLists(pageable, ids, entityTypeIds, active, _private, providedTimestamp));
+    return ResponseEntity.ok(listService.getAllLists(pageable, ids, entityTypeIds, active, isPrivate, providedTimestamp));
   }
 
   @Override

--- a/src/test/java/org/folio/list/ModListApplicationTest.java
+++ b/src/test/java/org/folio/list/ModListApplicationTest.java
@@ -2,7 +2,9 @@ package org.folio.list;
 
 import javax.validation.Valid;
 
+import org.folio.list.context.TestcontainerCallbackExtension;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Profile;
@@ -17,8 +19,9 @@ import org.folio.tenant.rest.resource.TenantApi;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ActiveProfiles({"test", "testcontainers-pg"})
+@ActiveProfiles({"test", "db-test"})
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ExtendWith(TestcontainerCallbackExtension.class)
 class ModListApplicationTest {
 
   @EnableAutoConfiguration(exclude = {FolioLiquibaseConfiguration.class})

--- a/src/test/java/org/folio/list/context/ReaderDatasourceFallbackTest.java
+++ b/src/test/java/org/folio/list/context/ReaderDatasourceFallbackTest.java
@@ -2,6 +2,7 @@ package org.folio.list.context;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ActiveProfiles("db-test")
 @SpringBootTest
+@ExtendWith(TestcontainerCallbackExtension.class)
 class ReaderDatasourceFallbackTest {
   @Autowired
   @Qualifier("readerDataSource")

--- a/src/test/java/org/folio/list/context/TestcontainerCallbackExtension.java
+++ b/src/test/java/org/folio/list/context/TestcontainerCallbackExtension.java
@@ -1,8 +1,7 @@
 package org.folio.list.context;
 
-import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
-import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -10,20 +9,23 @@ import org.testcontainers.junit.jupiter.Container;
 
 @Component
 @Profile("db-test")
-public class TestcontainerBeanFactoryPostProcessor implements BeanFactoryPostProcessor {
+public class TestcontainerCallbackExtension implements BeforeAllCallback {
   private static final int POSTGRES_PORT = 5432;
 
   @Container
   public static PostgreSQLContainer<?> dbContainer = new PostgreSQLContainer<>("postgres:12-alpine");
 
   @Override
-  public void postProcessBeanFactory(ConfigurableListableBeanFactory configurableListableBeanFactory) throws BeansException {
+  public void beforeAll(ExtensionContext context) {
     dbContainer.start();
-
     System.setProperty("DB_HOST", dbContainer.getHost());
     System.setProperty("DB_PORT", "" + dbContainer.getMappedPort(POSTGRES_PORT));
     System.setProperty("DB_DATABASE", dbContainer.getDatabaseName());
     System.setProperty("DB_USERNAME", dbContainer.getUsername());
     System.setProperty("DB_PASSWORD", dbContainer.getPassword());
+  }
+
+  public void afterAll(ExtensionContext context) {
+    // do nothing, Testcontainers handles container shutdown
   }
 }

--- a/src/test/java/org/folio/list/controller/ListConfigurationControllerTest.java
+++ b/src/test/java/org/folio/list/controller/ListConfigurationControllerTest.java
@@ -1,7 +1,9 @@
 package org.folio.list.controller;
 
+import org.folio.list.context.TestcontainerCallbackExtension;
 import org.folio.spring.integration.XOkapiHeaders;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -20,6 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 // Using db-test profile here to prevent this test from waiting on the db connection timeout from application.yml
 // This allows the test to run much faster, since it doesn't get stuck waiting for a db connection
 @ActiveProfiles("db-test")
+@ExtendWith(TestcontainerCallbackExtension.class)
 class ListConfigurationControllerTest {
   private static final String TENANT_ID = "test-tenant";
 


### PR DESCRIPTION
The field name in the API is "private" which can't be used, since it's a Java keyword, so OAS generates the interface with the param name "_private" - Sonar doesn't like that name, so instead, we use "isPrivate"
