### PR TITLE
MODLISTS-5 Enable batch inserts

### DIFF
--- a/src/main/java/org/folio/list/domain/ListContent.java
+++ b/src/main/java/org/folio/list/domain/ListContent.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Persistable;
 
 import javax.validation.constraints.NotNull;
 import java.util.UUID;
@@ -14,7 +15,8 @@ import java.util.UUID;
 @NoArgsConstructor
 @IdClass(ListContentId.class)
 @Table(name = "list_contents")
-public class ListContent {
+// Implements Persistable so that we can explicitly mark each object as new in the DB
+public class ListContent implements Persistable<ListContentId> {
   public static final int SORT_SEQUENCE_START_NUMBER = 0;
 
   @Column(name = "list_id")
@@ -34,4 +36,16 @@ public class ListContent {
 
   @Column(name = "sort_seq")
   private int sortSequence;
+
+  @Override
+  public ListContentId getId() {
+    return new ListContentId(listId, refreshId, contentId);
+  }
+
+  @Override
+  public boolean isNew() {
+    // We treat ListContents data as immutable in the DB, so it's *always* a new row
+    // Without this, on every insert, JPA does a SELECT to see if it's new before the INSERT
+    return true;
+  }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,8 @@ spring:
     hikari:
       # time in ms to wait for db connection
       initialization-fail-timeout: 1800000
+      data-source-properties:
+        reWriteBatchedInserts: true
   sql:
     init:
       # to boot up application despite of any DB connection issues
@@ -42,6 +44,8 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: true
+        jdbc:
+          batch_size: 50
     show-sql: false
   liquibase:
     enabled: true


### PR DESCRIPTION
This commit enables batch inserts (with a batch size of 50, which is the recommended max value, per
https://docs.jboss.org/hibernate/orm/4.0/devguide/en-US/html/ch04.html