### PR TITLE
MODLISTS-12 Update the container memory setting

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -167,13 +167,13 @@
     "dockerPull": false,
     "dockerArgs": {
       "HostConfig": {
-        "Memory": 357913941,
+        "Memory": 3221225472,
         "PortBindings": { "8081/tcp": [ { "HostPort": "%p" } ] }
       }
     },
     "env": [
       { "name": "JAVA_OPTIONS",
-        "value": "-XX:MaxRAMPercentage=66.0"
+        "value": "-XX:MaxRAMPercentage=66.0 -XX:MetaspaceSize=384m -XX:MaxMetaspaceSize=512m -Xmx2048m"
       },
       { "name": "server.port",
         "value": "8081"


### PR DESCRIPTION
This was set to a 3rd of a GiB before, when what we've been running on in other environments is 10x that, so this commit brings the module descriptor's container memory setting in-line with how we've actually been running the module