### PR TITLE
MODLISTS-13: Update UserFriendlyQueryService to handle contains and notContains operators

### DIFF
--- a/src/main/java/org/folio/list/services/UserFriendlyQueryService.java
+++ b/src/main/java/org/folio/list/services/UserFriendlyQueryService.java
@@ -29,8 +29,10 @@ public class UserFriendlyQueryService {
     GreaterThanCondition.class, (cnd, ent) -> handleGreaterThan((GreaterThanCondition) cnd),
     LessThanCondition.class, (cnd, ent) -> handleLessThan((LessThanCondition) cnd),
     AndCondition.class, (cnd, ent) -> handleAnd((AndCondition) cnd, ent),
-    RegexCondition.class, (cnd, ent) -> handleRegEx((RegexCondition) cnd)
-  );
+    RegexCondition.class, (cnd, ent) -> handleRegEx((RegexCondition) cnd),
+    ContainsCondition.class, (cnd, ent) -> handleContains((ContainsCondition) cnd, ent),
+    NotContainsCondition.class, (cnd, ent) -> handleNotContains((NotContainsCondition) cnd, ent)
+    );
 
   public String getUserFriendlyQuery(FqlCondition<?> fqlCondition, EntityType entityType) {
     log.info("Computing user friendly query for fqlCondition: {}, entityType: {}", fqlCondition, entityType.getId());
@@ -86,6 +88,16 @@ public class UserFriendlyQueryService {
       return getLabel(ids, col, true);
     };
     return handleConditionWithPossibleIdValue(notInCondition, entityType, "not in", labelFn);
+  }
+
+  private String handleContains(ContainsCondition containsCondition, EntityType entityType) {
+    BiFunction<EntityTypeColumn, Object, String> labelFn = (col, val) -> this.getLabel(UUID.fromString(val.toString()), col);
+    return handleConditionWithPossibleIdValue(containsCondition, entityType, "contains", labelFn);
+  }
+
+  private String handleNotContains(NotContainsCondition notContainsCondition, EntityType entityType) {
+    BiFunction<EntityTypeColumn, Object, String> labelFn = (col, val) -> this.getLabel(UUID.fromString(val.toString()), col);
+    return handleConditionWithPossibleIdValue(notContainsCondition, entityType, "does not contain", labelFn);
   }
 
   private <T> String handleConditionWithPossibleIdValue(FieldCondition<T> condition,

--- a/src/test/java/org/folio/list/service/UserFriendlyQueryServiceTest.java
+++ b/src/test/java/org/folio/list/service/UserFriendlyQueryServiceTest.java
@@ -174,6 +174,78 @@ class UserFriendlyQueryServiceTest {
   }
 
   @Test
+  void shouldGetStringForFqlContainsConditionWithoutIdColumn() {
+    EntityType entityType = new EntityType();
+    ContainsCondition containsCondition = new ContainsCondition("field1", "value1");
+    String expectedContainsCondition = "field1 contains value1";
+    String actualContainsCondition = userFriendlyQueryService.getUserFriendlyQuery(containsCondition, entityType);
+    assertEquals(expectedContainsCondition, actualContainsCondition);
+  }
+
+  @Test
+  void shouldGetStringForFqlContainsConditionWithIdColumn() {
+    List<Map<String, Object>> entityContents = List.of(
+      Map.of("field1", "value1")
+    );
+    UUID sourceEntityTypeId = UUID.randomUUID();
+    UUID value = UUID.randomUUID();
+    UUID entityTypeId = UUID.randomUUID();
+    List<String> fields = List.of("id", "field1");
+
+    SourceColumn sourceColumn = new SourceColumn().entityTypeId(sourceEntityTypeId.toString()).columnName("field1");
+    EntityTypeColumn column = new EntityTypeColumn().name("field1");
+    EntityTypeColumn column1 = new EntityTypeColumn().name("field2").idColumnName("field1").source(sourceColumn);
+    EntityType entityType = new EntityType().id(entityTypeId.toString()).columns(List.of(column, column1));
+    ContainsCondition containsCondition = new ContainsCondition("field1", value.toString());
+    List<UUID> ids = List.of(UUID.fromString(containsCondition.value().toString()));
+    ContentsRequest contentsRequest = new ContentsRequest().entityTypeId(sourceEntityTypeId)
+      .fields(fields)
+      .ids(ids);
+
+    when(queryClient.getContents(contentsRequest)).thenReturn(entityContents);
+
+    String expectedContainsCondition = "field2 contains value1";
+    String actualContainsConditions = userFriendlyQueryService.getUserFriendlyQuery(containsCondition, entityType);
+    assertEquals(expectedContainsCondition, actualContainsConditions);
+  }
+
+  @Test
+  void shouldGetStringForFqlNotContainsConditionWithoutIdColumn() {
+    EntityType entityType = new EntityType();
+    NotContainsCondition notContainsCondition = new NotContainsCondition("field1", "value1");
+    String expectedNotContainsCondition = "field1 does not contain value1";
+    String actualNotContainsCondition = userFriendlyQueryService.getUserFriendlyQuery(notContainsCondition, entityType);
+    assertEquals(expectedNotContainsCondition, actualNotContainsCondition);
+  }
+
+  @Test
+  void shouldGetStringForFqlNotContainsConditionWithIdColumn() {
+    List<Map<String, Object>> entityContents = List.of(
+      Map.of("field1", "value1")
+    );
+    UUID sourceEntityTypeId = UUID.randomUUID();
+    UUID value = UUID.randomUUID();
+    UUID entityTypeId = UUID.randomUUID();
+    List<String> fields = List.of("id", "field1");
+
+    SourceColumn sourceColumn = new SourceColumn().entityTypeId(sourceEntityTypeId.toString()).columnName("field1");
+    EntityTypeColumn column = new EntityTypeColumn().name("field1");
+    EntityTypeColumn column1 = new EntityTypeColumn().name("field2").idColumnName("field1").source(sourceColumn);
+    EntityType entityType = new EntityType().id(entityTypeId.toString()).columns(List.of(column, column1));
+    NotContainsCondition notContainsCondition = new NotContainsCondition("field1", value.toString());
+    List<UUID> ids = List.of(UUID.fromString(notContainsCondition.value().toString()));
+    ContentsRequest contentsRequest = new ContentsRequest().entityTypeId(sourceEntityTypeId)
+      .fields(fields)
+      .ids(ids);
+
+    when(queryClient.getContents(contentsRequest)).thenReturn(entityContents);
+
+    String expectedNotContainsCondition = "field2 does not contain value1";
+    String actualNotContainsConditions = userFriendlyQueryService.getUserFriendlyQuery(notContainsCondition, entityType);
+    assertEquals(expectedNotContainsCondition, actualNotContainsConditions);
+  }
+
+  @Test
   void shouldGetStringForFqlGreaterThanCondition() {
     EntityType entityType = new EntityType();
     GreaterThanCondition greaterThanCondition = new GreaterThanCondition("field1", false, "some value");


### PR DESCRIPTION
## Purpose
[Update UserFriendlyQueryService to handle contains and notContains operators](https://issues.folio.org/browse/MODLISTS-13)

## Testing
- [x] All unit tests passed
- [x] Contains and not contains operators are handled correctly in the user friendly query
<img width="942" alt="Screenshot 2023-09-19 at 10 47 45 AM" src="https://github.com/folio-org/mod-lists/assets/97990858/41c5f158-86ac-4d48-aabe-03fa96f3150e">

