### PR TITLE
MODLISTS-4 Add missing sections to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,3 +251,42 @@ Response
 * Content Type: text/csv
 
 The response the csv of the downloaded list.
+
+## Additional information
+
+### Issue tracker
+
+See project [MODLISTS](https://issues.folio.org/browse/MODLISTS)
+at the [FOLIO issue tracker](https://dev.folio.org/guidelines/issue-tracker).
+
+### Code of Conduct
+
+Refer to the Wiki
+[FOLIO Code of Conduct](https://wiki.folio.org/display/COMMUNITY/FOLIO+Code+of+Conduct).
+
+### ModuleDescriptor
+
+See the [ModuleDescriptor](descriptors/ModuleDescriptor-template.json)
+for the interfaces that this module requires and provides, the permissions,
+and the additional module metadata.
+
+### API documentation
+
+API descriptions:
+
+* [OpenAPI](src/main/resources/swagger.api/list.yaml)
+* [Schemas](src/main/resources/swagger.api/schemas/)
+
+Generated [API documentation](https://dev.folio.org/reference/api/#mod-lists)
+
+### Code analysis
+
+[SonarQube analysis](https://sonarcloud.io/project/overview?id=org.folio%3Amod-lists).
+
+### Download and configuration
+
+The built artifacts for this module are available.
+See [configuration](https://dev.folio.org/download/artifacts) for repository access,
+and the Docker images for [released versions](https://hub.docker.com/r/folioorg/mod-lists/)
+and for [snapshot versions](https://hub.docker.com/r/folioci/mod-lists/).
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # mod-lists
+Copyright (C) 2023 The Open Library Foundation
 
-mod-lists is responsible for persisting the meta-data and the contents (IDs) of the lists.
+This software is distributed under the terms of the Apache License,
+Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
+
+## Introduction
+mod-lists is responsible for persisting the metadata and the contents (IDs) of lists.
 
 ## Architecture
 The "mod-lists" module is responsible for handling lists within the system. It provides a set of REST endpoints that enable users to perform CRUD (Create, Read, Update, Delete) operations on lists. To efficiently query the data, the module leverages the "lib-fqm-query-processor" library, which streamlines the process of querying the underlying data storage, such as a database or file system.


### PR DESCRIPTION
## Purpose
This adds the required license and issue tracker stuff (per https://dev.folio.org/guidelines/create-new-repo/) to the README. For both sections, I used mod-settings as a reference. The mod-settings "Additional Information" is generally very good, so I included pretty much the whole section instead of just the issue tracker link.