### PR TITLE
MODFQMMGR-3 Use more specific FQM interfaces

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -3,11 +3,6 @@
   "name": "The module descriptor for mod-lists",
   "provides": [
     {
-      "id": "mod-lists",
-      "version": "1.0",
-      "handlers": []
-    },
-    {
       "id": "_tenant",
       "version": "1.2",
       "interfaceType": "system",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -149,7 +149,11 @@
   ],
   "requires": [
     {
-      "id": "mod-fqm-manager",
+      "id": "fqm-query",
+      "version": "1.0"
+    },
+    {
+      "id": "entity-types",
       "version": "1.0"
     },
     {


### PR DESCRIPTION
This commit changes the module's declared dependencies in the module descriptor from "mod-fqm-manager" to the more specific "entity-types" and "query" as the old one is going away and we need to use the more specific ones anyway