### PR TITLE
MODLISTS-22: Fix api-lint errors

### DIFF
--- a/src/main/resources/swagger.api/schemas/ListAppError.json
+++ b/src/main/resources/swagger.api/schemas/ListAppError.json
@@ -15,7 +15,6 @@
       "description": "Error message code"
     },
     "parameters": {
-      "type": "object",
       "description": "Error message parameters",
       "$ref": "parameters.json"
     }

--- a/src/main/resources/swagger.api/schemas/ListDTO.json
+++ b/src/main/resources/swagger.api/schemas/ListDTO.json
@@ -82,17 +82,14 @@
     },
     "successRefresh": {
       "description": "List Refresh Information",
-      "type": "object",
       "$ref": "ListRefreshDTO.json"
     },
     "inProgressRefresh": {
       "description": "List In-Progress Refresh Information",
-      "type": "object",
       "$ref": "ListRefreshDTO.json"
     },
     "failedRefresh": {
       "description": "List Failed Refresh Information",
-      "type": "object",
       "$ref": "ListRefreshDTO.json"
     },
     "version": {

--- a/src/main/resources/swagger.api/schemas/ListRefreshDTO.json
+++ b/src/main/resources/swagger.api/schemas/ListRefreshDTO.json
@@ -47,7 +47,6 @@
     },
     "error": {
       "description": "Error encountered during list refresh",
-      "type": "object",
       "$ref": "ListAppError.json"
     }
   },

--- a/src/main/resources/swagger.api/schemas/ListSummaryResultsDTO.json
+++ b/src/main/resources/swagger.api/schemas/ListSummaryResultsDTO.json
@@ -7,7 +7,6 @@
       "description": "array of content",
       "type": "array",
       "items": {
-        "type": "object",
         "$ref": "#/ListSummaryDTO"
       }
     },

--- a/src/main/resources/swagger.api/schemas/parameters.json
+++ b/src/main/resources/swagger.api/schemas/parameters.json
@@ -2,8 +2,6 @@
   "description": "List of key/value parameters of an error",
   "type": "array",
   "items": {
-    "type": "object",
     "$ref": "parameter.json"
-  },
-  "additionalProperties": false
+  }
 }


### PR DESCRIPTION
## Purpose
[MODLISTS-22: Fix api-lint errors](https://issues.folio.org/browse/MODLISTS-22)

## Testing
- [x] mod-lists can be built with no lint errors
