### PR TITLE
MODLISTS-23: Fix Jenkins build errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM folioci/alpine-jre-openjdk17:latest
 
+# Install latest patch versions of packages
+USER root
+RUN apk upgrade --no-cache
+USER folio
+
 # Copy your fat jar to the container provide the actual name for your fat jar file for example mod-notes-fat.jar
 ENV APP_FILE mod-lists.jar
 # - should be a single jar file

--- a/pom.xml
+++ b/pom.xml
@@ -33,10 +33,12 @@
     <aws-sdk-java.version>2.19.2</aws-sdk-java.version>
     <folio-s3-client.version>1.1.0-SNAPSHOT</folio-s3-client.version>
     <awaitility.version>4.2.0</awaitility.version>
+    <snakeyaml.version>2.0</snakeyaml.version>
+    <snappy-java.version>1.1.10.5</snappy-java.version>
 
     <!-- test dependencies -->
     <testcontainers.version>1.17.6</testcontainers.version>
-    <wiremock.version>2.35.0</wiremock.version>
+    <wiremock.version>3.2.0</wiremock.version>
     <junit-extensions.version>2.6.0</junit-extensions.version>
     <easy-random.version>5.0.0</easy-random.version>
 
@@ -145,6 +147,14 @@
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>${snakeyaml.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+
+
     <!-- AWS S3 dependencies -->
     <dependency>
       <groupId>org.folio</groupId>
@@ -156,6 +166,12 @@
       <artifactId>aws-sdk-java</artifactId>
       <version>${aws-sdk-java.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+      <version>${snappy-java.version}</version>
+    </dependency>
+
 
     <!-- Test dependencies -->
     <dependency>
@@ -186,8 +202,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
## Purpose
[MODLISTS-23: Fix Jenkins build errors](https://issues.folio.org/browse/MODLISTS-23)

## Testing
 - [x] App functions normally
 - [x] Builds no longer fail image scan (Note: there are still 2 failing vulnerabilities, but these are not direct dependencies of the project and are related to the container itself)
