### PR TITLE
MODLISTS-22: Fix remaining api-lint errors

### DIFF
--- a/.github/workflows/api-lint.yml
+++ b/.github/workflows/api-lint.yml
@@ -62,4 +62,4 @@ jobs:
             --types ${{ env.API_TYPES }} \
             --directories ${{ env.API_DIRECTORIES }} \
             --excludes ${{ env.API_EXCLUDES }} \
-            ${{ env.OPTION_WARNINGS }}
+            -w

--- a/src/main/resources/swagger.api/list.yaml
+++ b/src/main/resources/swagger.api/list.yaml
@@ -96,7 +96,7 @@ paths:
               $ref: '#/components/schemas/ListRequestDTO'
       responses:
         '201':
-          description: 'returns if a list created successfully'
+          description: 'returns if list created successfully'
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Purpose
[MODLISTS-22: Fix remaining api-lint errors](https://issues.folio.org/browse/MODLISTS-22)

## Testing
- [ ] App functions normally
- [ ] App can be built with no api-lint errors
