### PR TITLE
Refactor refresh sorting logic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <commons-collections4.version>4.4</commons-collections4.version>
     <folio-service-tools.version>3.1.0</folio-service-tools.version>
     <mapstruct.version>1.5.2.Final</mapstruct.version>
-    <lib-fqm-query-processor.version>1.0.0</lib-fqm-query-processor.version>
+    <lib-fqm-query-processor.version>1.1.0-SNAPSHOT</lib-fqm-query-processor.version>
     <jackson-dataformat-csv.version>2.14.2</jackson-dataformat-csv.version>
     <aws-sdk-java.version>2.19.2</aws-sdk-java.version>
     <folio-s3-client.version>1.1.0</folio-s3-client.version>

--- a/src/main/java/org/folio/list/services/refresh/ListRefreshService.java
+++ b/src/main/java/org/folio/list/services/refresh/ListRefreshService.java
@@ -47,23 +47,10 @@ public class ListRefreshService {
       SubmitQuery submitQuery = new SubmitQuery()
         .entityTypeId(list.getEntityTypeId())
         .fqlQuery(list.getFqlQuery())
-        .fields(list.getFields());
+        .fields(list.getFields())
+        .sortResults(true);
       QueryIdentifier queryIdentifier = queryClient.executeQuery(submitQuery);
       waitForQueryCompletion(list, queryIdentifier.getQueryId());
-    } catch (Exception exception) {
-      log.error("Unexpected error when performing async refresh for list with id " + list.getId()
-        + ", refreshId " + (list.getInProgressRefreshId().map(UUID::toString).orElse("NONE")), exception);
-      refreshFailedCallback.accept(list, exception);
-    }
-  }
-
-  @Async
-  @Transactional(propagation = Propagation.NOT_SUPPORTED)
-  public void doAsyncSorting(ListEntity list, UUID queryId, ShutdownTask shutdownTask) {
-    try (var autoCloseMe = shutdownTask) {
-      log.info("Performing async sorting for list {}, refreshId {}", list.getId(),
-        list.getInProgressRefreshId().map(UUID::toString).orElse("NONE"));
-      waitForQueryCompletion(list, queryId);
     } catch (Exception exception) {
       log.error("Unexpected error when performing async refresh for list with id " + list.getId()
         + ", refreshId " + (list.getInProgressRefreshId().map(UUID::toString).orElse("NONE")), exception);

--- a/src/main/resources/db/changelog/changes/v1.0.0/sql/create-list-contents-table.sql
+++ b/src/main/resources/db/changelog/changes/v1.0.0/sql/create-list-contents-table.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS list_contents
     list_id         UUID  NOT NULL,
     refresh_id      UUID NOT NULL,
     content_id      UUID  NOT NULL,
-    sort_seq        numeric NOT NULL,
+    sort_seq        INTEGER NOT NULL,
     CONSTRAINT  pk_composite PRIMARY KEY (list_id, refresh_id, content_id),
     CONSTRAINT fk_report_id FOREIGN KEY (list_id)
                 REFERENCES list_details (id) MATCH SIMPLE,

--- a/src/test/java/org/folio/list/service/ListRefreshServiceTest.java
+++ b/src/test/java/org/folio/list/service/ListRefreshServiceTest.java
@@ -67,17 +67,6 @@ class ListRefreshServiceTest {
   }
 
   @Test
-  void shouldStartAsyncSort() {
-    UUID queryId = UUID.randomUUID();
-    ListEntity list = TestDataFixture.getListEntityWithSuccessRefresh();
-    int totalRecords = 0;
-    QueryDetails queryDetails = new QueryDetails().status(QueryDetails.StatusEnum.SUCCESS).totalRecords(totalRecords);
-    when(queryClient.getQuery(queryId)).thenReturn(queryDetails);
-    listRefreshService.doAsyncSorting(list, queryId, null);
-    verify(refreshSuccessCallback, times(1)).accept(list, totalRecords);
-  }
-
-  @Test
   void shouldHandleQueryCancelledDuringRefresh() {
     ListEntity list = TestDataFixture.getListEntityWithSuccessRefresh();
     int totalRecords = 0;


### PR DESCRIPTION
## Purpose
Refactor refresh sorting logic so that query results are sorted during query execution, instead of while importing results

## Testing
- [ ] All unit tests passed
- [ ] List refreshes work normally
- [ ] Posting list with query works normally
