### PR TITLE
MODLISTS-40 Move 1.0.1 DB changes to their own changelog

### DIFF
--- a/src/main/resources/db/changelog/changes/v1.0.0/sql/create-list-refresh-details-table.sql
+++ b/src/main/resources/db/changelog/changes/v1.0.0/sql/create-list-refresh-details-table.sql
@@ -12,9 +12,6 @@ CREATE TABLE IF NOT EXISTS list_refresh_details
     content_version         NUMERIC,
     error_code              VARCHAR(64),
     error_message           VARCHAR(1024),
-    metadata                JSONB,
     CONSTRAINT fk_report_id FOREIGN KEY (list_id)
        REFERENCES list_details (id) MATCH SIMPLE ON DELETE CASCADE
 );
-
-ALTER TABLE list_refresh_details ADD COLUMN IF NOT EXISTS metadata JSONB;

--- a/src/main/resources/db/changelog/changes/v1.0.1/changelog-v1.0.1.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.1/changelog-v1.0.1.xml
@@ -2,8 +2,12 @@
 <databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
 
-  <include file="changes/v1.0.0/changelog-v1.0.0.xml" relativeToChangelogFile="true"/>
-  <include file="changes/v1.0.0/changelog-v1.0.1.xml" relativeToChangelogFile="true"/>
+  <changeSet id="add-metadata-to-list-refresh-details" author="mweaver@ebsco.com">
+    <sql>
+      ALTER TABLE list_refresh_details ADD COLUMN IF NOT EXISTS metadata JSONB;
+    </sql>
+  </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
This moves the changes made since 1.0.0 to a new changelog file in order to make migrations work better