### PR TITLE
MODLISTS-46 - Update the provided _tenant interface version

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,15 +4,18 @@
   "provides": [
     {
       "id": "_tenant",
-      "version": "1.2",
+      "version": "2.0",
       "interfaceType": "system",
       "handlers": [
         {
           "methods": ["POST"],
-          "pathPattern": "/_/tenant"
-        }, {
-          "methods": ["DELETE"],
-          "pathPattern": "/_/tenant"
+          "pathPattern": "/_/tenant",
+          "permissionsRequired": []
+        },
+        {
+          "methods": ["GET", "DELETE"],
+          "pathPattern": "/_/tenant/{id}",
+          "permissionsRequired": []
         }
       ]
     },


### PR DESCRIPTION
This commit makes mod-lists provide the _tenant 2.0 interface, which will make Okapi use the POST /_/tenant API for all tenant actions