### PR TITLE
[MODFQMMGR-87] Use new centralized lib patterns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <commons-collections4.version>4.4</commons-collections4.version>
     <folio-service-tools.version>3.1.0</folio-service-tools.version>
     <mapstruct.version>1.5.2.Final</mapstruct.version>
-    <lib-fqm-query-processor.version>modfqmmgr-87-SNAPSHOT</lib-fqm-query-processor.version>
+    <lib-fqm-query-processor.version>1.1.0-SNAPSHOT</lib-fqm-query-processor.version>
     <jackson-dataformat-csv.version>2.14.2</jackson-dataformat-csv.version>
     <aws-sdk-java.version>2.19.2</aws-sdk-java.version>
     <folio-s3-client.version>2.0.5</folio-s3-client.version>
@@ -68,7 +68,7 @@
       <version>${folio-spring-base.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.github.folio-org</groupId>
+      <groupId>org.folio</groupId>
       <artifactId>lib-fqm-query-processor</artifactId>
       <version>${lib-fqm-query-processor.version}</version>
     </dependency>
@@ -393,11 +393,6 @@
       <id>folio-nexus</id>
       <name>FOLIO Maven repository</name>
       <url>https://repository.folio.org/repository/maven-folio</url>
-    </repository>
-
-    <repository>
-      <id>jitpack.io</id>
-      <url>https://www.jitpack.io</url>
     </repository>
   </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <commons-collections4.version>4.4</commons-collections4.version>
     <folio-service-tools.version>3.1.0</folio-service-tools.version>
     <mapstruct.version>1.5.2.Final</mapstruct.version>
-    <lib-fqm-query-processor.version>1.0.0</lib-fqm-query-processor.version>
+    <lib-fqm-query-processor.version>1.1.0-SNAPSHOT</lib-fqm-query-processor.version>
     <jackson-dataformat-csv.version>2.14.2</jackson-dataformat-csv.version>
     <aws-sdk-java.version>2.19.2</aws-sdk-java.version>
     <folio-s3-client.version>2.0.5</folio-s3-client.version>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <commons-collections4.version>4.4</commons-collections4.version>
     <folio-service-tools.version>3.1.0</folio-service-tools.version>
     <mapstruct.version>1.5.2.Final</mapstruct.version>
-    <lib-fqm-query-processor.version>1.1.0-SNAPSHOT</lib-fqm-query-processor.version>
+    <lib-fqm-query-processor.version>modfqmmgr-87-SNAPSHOT</lib-fqm-query-processor.version>
     <jackson-dataformat-csv.version>2.14.2</jackson-dataformat-csv.version>
     <aws-sdk-java.version>2.19.2</aws-sdk-java.version>
     <folio-s3-client.version>2.0.5</folio-s3-client.version>
@@ -393,6 +393,11 @@
       <id>folio-nexus</id>
       <name>FOLIO Maven repository</name>
       <url>https://repository.folio.org/repository/maven-folio</url>
+    </repository>
+
+    <repository>
+      <id>jitpack.io</id>
+      <url>https://www.jitpack.io</url>
     </repository>
   </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
       <version>${folio-spring-base.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.folio</groupId>
+      <groupId>com.github.folio-org</groupId>
       <artifactId>lib-fqm-query-processor</artifactId>
       <version>${lib-fqm-query-processor.version}</version>
     </dependency>

--- a/src/main/java/org/folio/list/ModListsApplication.java
+++ b/src/main/java/org/folio/list/ModListsApplication.java
@@ -1,6 +1,8 @@
 package org.folio.list;
 
+import org.folio.fql.config.FqlConfiguration;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
@@ -10,10 +12,10 @@ import org.springframework.scheduling.annotation.EnableAsync;
 @EnableAsync
 @EnableFeignClients
 @ConfigurationPropertiesScan
+@ImportAutoConfiguration(classes = { FqlConfiguration.class })
 public class ModListsApplication {
 
   public static void main(String[] args) {
     SpringApplication.run(ModListsApplication.class, args);
   }
-
 }

--- a/src/main/java/org/folio/list/ModListsApplication.java
+++ b/src/main/java/org/folio/list/ModListsApplication.java
@@ -1,8 +1,6 @@
 package org.folio.list;
 
-import org.folio.fql.config.FqlConfiguration;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
@@ -12,7 +10,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
 @EnableAsync
 @EnableFeignClients
 @ConfigurationPropertiesScan
-@ImportAutoConfiguration(classes = { FqlConfiguration.class })
 public class ModListsApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/org/folio/list/configuration/ListAppConfiguration.java
+++ b/src/main/java/org/folio/list/configuration/ListAppConfiguration.java
@@ -1,9 +1,6 @@
 package org.folio.list.configuration;
 
 import lombok.RequiredArgsConstructor;
-import org.folio.fql.FqlService;
-import org.folio.fqm.lib.service.FqlValidationService;
-import org.folio.fqm.lib.FQM;
 import org.folio.list.domain.dto.ListConfiguration;
 import org.folio.list.repository.ListContentsRepository;
 import org.folio.list.repository.ListRefreshRepository;
@@ -22,16 +19,6 @@ import java.util.function.Supplier;
 @RequiredArgsConstructor
 public class ListAppConfiguration {
   private final ListExportProperties listExportProperties;
-
-  @Bean
-  public FqlService fqlService() {
-    return new FqlService();
-  }
-
-  @Bean
-  public FqlValidationService fqlValidationService() {
-    return FQM.fqlValidationService();
-  }
 
   @Bean
   @Lazy // Do not connect to S3 when the application starts

--- a/src/main/java/org/folio/list/services/ListService.java
+++ b/src/main/java/org/folio/list/services/ListService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.folio.fql.FqlService;
+import org.folio.fql.service.FqlService;
 import org.folio.fql.model.Fql;
 import org.folio.list.domain.ListContent;
 import org.folio.list.domain.ListRefreshDetails;

--- a/src/main/java/org/folio/list/services/ListValidationService.java
+++ b/src/main/java/org/folio/list/services/ListValidationService.java
@@ -1,7 +1,7 @@
 package org.folio.list.services;
 
 import lombok.RequiredArgsConstructor;
-import org.folio.fql.FqlValidationService;
+import org.folio.fql.service.FqlValidationService;
 import org.folio.list.domain.AsyncProcessStatus;
 import org.folio.list.domain.ExportDetails;
 import org.folio.list.domain.ListEntity;

--- a/src/main/java/org/folio/list/services/ListValidationService.java
+++ b/src/main/java/org/folio/list/services/ListValidationService.java
@@ -1,7 +1,7 @@
 package org.folio.list.services;
 
 import lombok.RequiredArgsConstructor;
-import org.folio.fqm.lib.service.FqlValidationService;
+import org.folio.fql.FqlValidationService;
 import org.folio.list.domain.AsyncProcessStatus;
 import org.folio.list.domain.ExportDetails;
 import org.folio.list.domain.ListEntity;

--- a/src/test/java/org/folio/list/service/ListRefreshServiceTest.java
+++ b/src/test/java/org/folio/list/service/ListRefreshServiceTest.java
@@ -1,6 +1,5 @@
 package org.folio.list.service;
 
-import org.folio.fqm.lib.service.QueryResultsSorterService;
 import org.folio.list.domain.ListEntity;
 import org.folio.list.repository.ListContentsRepository;
 import org.folio.list.repository.ListRepository;
@@ -36,8 +35,6 @@ class ListRefreshServiceTest {
 
   @Mock
   private QueryClient queryClient;
-  @Mock
-  private QueryResultsSorterService queryResultsService;
   @Mock
   private FolioExecutionContext executionContext;
   @Mock

--- a/src/test/java/org/folio/list/service/ListServiceGetListContentsTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceGetListContentsTest.java
@@ -1,6 +1,6 @@
 package org.folio.list.service;
 
-import org.folio.fql.FqlService;
+import org.folio.fql.service.FqlService;
 import org.folio.list.domain.ListContent;
 import org.folio.list.domain.ListEntity;
 import org.folio.list.domain.ListRefreshDetails;

--- a/src/test/java/org/folio/list/service/ListServiceTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceTest.java
@@ -1,6 +1,6 @@
 package org.folio.list.service;
 
-import org.folio.fql.FqlService;
+import org.folio.fql.service.FqlService;
 import org.folio.fql.model.EqualsCondition;
 import org.folio.fql.model.Fql;
 import org.folio.list.domain.ListEntity;

--- a/src/test/java/org/folio/list/service/ListServiceValidateCreateTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceValidateCreateTest.java
@@ -1,6 +1,6 @@
 package org.folio.list.service;
 
-import org.folio.fql.FqlValidationService;
+import org.folio.fql.service.FqlValidationService;
 import org.folio.list.domain.dto.ListRequestDTO;
 import org.folio.list.exception.InvalidFqlException;
 import org.folio.list.services.ListValidationService;

--- a/src/test/java/org/folio/list/service/ListServiceValidateCreateTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceValidateCreateTest.java
@@ -1,6 +1,6 @@
 package org.folio.list.service;
 
-import org.folio.fqm.lib.service.FqlValidationService;
+import org.folio.fql.FqlValidationService;
 import org.folio.list.domain.dto.ListRequestDTO;
 import org.folio.list.exception.InvalidFqlException;
 import org.folio.list.services.ListValidationService;

--- a/src/test/java/org/folio/list/service/ListServiceValidateUpdateTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceValidateUpdateTest.java
@@ -1,6 +1,6 @@
 package org.folio.list.service;
 
-import org.folio.fql.FqlValidationService;
+import org.folio.fql.service.FqlValidationService;
 import org.folio.list.domain.ListEntity;
 import org.folio.list.domain.dto.ListUpdateRequestDTO;
 import org.folio.list.exception.*;

--- a/src/test/java/org/folio/list/service/ListServiceValidateUpdateTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceValidateUpdateTest.java
@@ -1,6 +1,6 @@
 package org.folio.list.service;
 
-import org.folio.fqm.lib.service.FqlValidationService;
+import org.folio.fql.FqlValidationService;
 import org.folio.list.domain.ListEntity;
 import org.folio.list.domain.dto.ListUpdateRequestDTO;
 import org.folio.list.exception.*;


### PR DESCRIPTION
# [Jira MODFQMMGR-87](https://issues.folio.org/browse/MODFQMMGR-87)

https://github.com/folio-org/lib-fqm-query-processor/pull/13 removes essentially the entire `org.folio.fqm.lib` package, with the exception of `FqlValidationService`, which is moved to `org.folio.fql.lib`.  It also adds spring autowiring/etc support to the FQL services.

This PR updates `mod-lists` to accept these new beans and packages.

# SHOULD BE MERGED AFTER https://github.com/folio-org/lib-fqm-query-processor/pull/13
