### PR TITLE
b1.0 -> master

### DIFF
--- a/src/main/java/org/folio/list/ModListsApplication.java
+++ b/src/main/java/org/folio/list/ModListsApplication.java
@@ -5,10 +5,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @SpringBootApplication
 @EnableAsync
 @EnableFeignClients
+@EnableTransactionManagement
 @ConfigurationPropertiesScan
 public class ModListsApplication {
 

--- a/src/main/java/org/folio/list/services/EntityManagerFlushService.java
+++ b/src/main/java/org/folio/list/services/EntityManagerFlushService.java
@@ -1,0 +1,23 @@
+package org.folio.list.services;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class EntityManagerFlushService {
+
+  @PersistenceContext
+  private final EntityManager entityManager;
+
+  public void flush() {
+    synchronized (entityManager) {
+      entityManager.flush();
+      entityManager.clear();
+    }
+  }
+}

--- a/src/main/java/org/folio/list/services/refresh/ListRefreshService.java
+++ b/src/main/java/org/folio/list/services/refresh/ListRefreshService.java
@@ -8,6 +8,7 @@ import org.folio.list.domain.ListEntity;
 import org.folio.list.exception.RefreshCancelledException;
 import org.folio.list.rest.QueryClient;
 import org.folio.list.services.AppShutdownService.ShutdownTask;
+import org.folio.list.services.EntityManagerFlushService;
 import org.folio.list.util.TaskTimer;
 import org.folio.querytool.domain.dto.QueryDetails;
 import org.folio.querytool.domain.dto.QueryIdentifier;
@@ -35,6 +36,7 @@ public class ListRefreshService {
   private final RefreshFailedCallback refreshFailedCallback;
   private final Supplier<DataBatchCallback> dataBatchCallbackSupplier;
   private final QueryClient queryClient;
+  private final EntityManagerFlushService entityManagerFlushService;
 
   @Async
   // Long-running method. Running this method within a transaction boundary will hog db connection for
@@ -93,6 +95,7 @@ public class ListRefreshService {
     } else if (queryDetails.getStatus() == QueryDetails.StatusEnum.CANCELLED) {
       refreshFailedCallback.accept(list, timer, new RefreshCancelledException(list));
     }
+    entityManagerFlushService.flush();
   }
 
   private int importQueryResults(ListEntity list, UUID queryId) {

--- a/src/main/java/org/folio/list/services/refresh/RefreshSuccessCallback.java
+++ b/src/main/java/org/folio/list/services/refresh/RefreshSuccessCallback.java
@@ -5,6 +5,7 @@ import lombok.extern.log4j.Log4j2;
 import org.folio.list.domain.ListEntity;
 import org.folio.list.repository.ListContentsRepository;
 import org.folio.list.repository.ListRepository;
+import org.folio.list.services.EntityManagerFlushService;
 import org.folio.list.util.TaskTimer;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +19,7 @@ import java.util.function.Predicate;
 public class RefreshSuccessCallback implements SuccessCallback {
   private final ListRepository listRepository;
   private final ListContentsRepository listContentsRepository;
+  private final EntityManagerFlushService entityManagerFlushService;
 
   @Transactional
   public void accept(ListEntity entity, int recordsCount, TaskTimer timer) {
@@ -43,6 +45,7 @@ public class RefreshSuccessCallback implements SuccessCallback {
         }
         entity.refreshCompleted(recordsCount, timer);
         timer.time(TimedStage.WRITE_END, () -> listRepository.save(entity));
+        entityManagerFlushService.flush();
     } else {
       listContentsRepository.deleteContents(entity.getId(), currentRefreshId);
     }

--- a/src/test/java/org/folio/list/service/ListRefreshServiceTest.java
+++ b/src/test/java/org/folio/list/service/ListRefreshServiceTest.java
@@ -5,6 +5,7 @@ import org.folio.list.domain.ListEntity;
 import org.folio.list.repository.ListContentsRepository;
 import org.folio.list.repository.ListRepository;
 import org.folio.list.rest.QueryClient;
+import org.folio.list.services.EntityManagerFlushService;
 import org.folio.list.services.refresh.ListRefreshService;
 import org.folio.list.services.refresh.RefreshFailedCallback;
 import org.folio.list.services.refresh.RefreshSuccessCallback;
@@ -53,6 +54,8 @@ class ListRefreshServiceTest {
   private Supplier<BiConsumer<ListEntity, List<UUID>>> listBatchCallbackSupplier;
   @InjectMocks
   private ListRefreshService listRefreshService;
+  @Mock
+  private EntityManagerFlushService entityManagerFlushService;
 
   @Test
   void shouldStartRefresh() {

--- a/src/test/java/org/folio/list/service/refresh/RefreshSuccessCallbackTest.java
+++ b/src/test/java/org/folio/list/service/refresh/RefreshSuccessCallbackTest.java
@@ -3,6 +3,7 @@ package org.folio.list.service.refresh;
 import org.folio.list.domain.ListEntity;
 import org.folio.list.repository.ListContentsRepository;
 import org.folio.list.repository.ListRepository;
+import org.folio.list.services.EntityManagerFlushService;
 import org.folio.list.services.refresh.RefreshSuccessCallback;
 import org.folio.list.util.TaskTimer;
 import org.folio.list.utils.TestDataFixture;
@@ -27,6 +28,9 @@ class RefreshSuccessCallbackTest {
 
   @Mock
   private ListContentsRepository listContentsRepository;
+
+  @Mock
+  private EntityManagerFlushService entityManagerFlushService;
 
   @InjectMocks
   private RefreshSuccessCallback successRefreshService;


### PR DESCRIPTION
This brings in the MODLISTS-66 changes, which manually flush the entity manager to avoid a couple of different race conditions.