### PR TITLE
MODLISTS-61 and MODLISTS-72: Implementing list versioning through end point

### DIFF
--- a/src/main/java/org/folio/list/controller/ListController.java
+++ b/src/main/java/org/folio/list/controller/ListController.java
@@ -6,6 +6,7 @@ import org.folio.list.domain.dto.ListRefreshDTO;
 import org.folio.list.domain.dto.ListRequestDTO;
 import org.folio.list.domain.dto.ListSummaryResultsDTO;
 import org.folio.list.domain.dto.ListUpdateRequestDTO;
+import org.folio.list.domain.dto.ListVersionDTO;
 import org.folio.list.exception.ListNotFoundException;
 import org.folio.list.rest.resource.ListApi;
 import org.folio.list.services.ListActions;
@@ -89,5 +90,14 @@ public class ListController implements ListApi {
   public ResponseEntity<Void> cancelRefresh(UUID listId) {
     listService.cancelRefresh(listId);
     return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+  }
+
+  @Override
+  public ResponseEntity<List<ListVersionDTO>> getListVersions(UUID listId) {
+    var listVersionDto = listService.getListVersions(listId);
+    if (listVersionDto == null || listVersionDto.isEmpty()) {
+      throw new ListNotFoundException(listId, ListActions.READ);
+    }
+    return new ResponseEntity<>(listVersionDto, HttpStatus.OK);
   }
 }

--- a/src/main/java/org/folio/list/domain/ListVersion.java
+++ b/src/main/java/org/folio/list/domain/ListVersion.java
@@ -1,0 +1,92 @@
+package org.folio.list.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import org.folio.list.rest.UsersClient.User;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "list_versions")
+public class ListVersion {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  @Column(updatable = false)
+  private UUID id;
+
+  @Column(name = "list_id")
+  @NotNull
+  private UUID listId;
+
+  @Column(name = "name")
+  @NotNull
+  @Size(min = 4, max = 255)
+  private String name;
+
+  @Column(name = "description")
+  @Size(min = 4, max = 255)
+  private String description;
+
+  @Column(name = "fql_query")
+  @Size(min = 4, max = 1024)
+  private String fqlQuery;
+
+  @Column(name = "fields")
+  private List<String> fields;
+
+  @Column(name = "updated_by")
+  @NotNull
+  private UUID updatedBy;
+
+  @Column(name = "updated_by_username")
+  @NotNull
+  @Size(min = 4, max = 1024)
+  private String updatedByUsername;
+
+  @Column(name = "updated_date")
+  private OffsetDateTime updatedDate;
+
+  @Column(name = "is_active")
+  @NotNull
+  private Boolean isActive;
+
+  @Column(name = "is_private")
+  @NotNull
+  private Boolean isPrivate;
+
+
+  @Column(name = "version")
+  @NotNull
+  private int version;
+
+  @Column(name = "user_friendly_query")
+  private String userFriendlyQuery;
+
+  public void setDataFromListEntity(ListEntity listEntity, User user) {
+    listId = listEntity.getId();
+    name = listEntity.getName();
+    fqlQuery = listEntity.getFqlQuery();
+    description = listEntity.getDescription();
+    userFriendlyQuery = listEntity.getUserFriendlyQuery();
+    fields = listEntity.getFields();
+    updatedBy = user.id();
+    updatedByUsername = user.getFullName().orElse(user.id().toString());
+    updatedDate = OffsetDateTime.now();
+    version = listEntity.getVersion();
+    isActive = listEntity.getIsActive();
+    isPrivate = listEntity.getIsPrivate();
+  }
+
+}

--- a/src/main/java/org/folio/list/mapper/ListVersionMapper.java
+++ b/src/main/java/org/folio/list/mapper/ListVersionMapper.java
@@ -1,0 +1,24 @@
+package org.folio.list.mapper;
+
+import org.folio.list.domain.ListVersion;
+import org.folio.list.domain.dto.ListVersionDTO;
+import org.mapstruct.*;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING, injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+  uses = {MappingMethods.class, ListRefreshMapper.class}, builder = @Builder(disableBuilder = true))
+public interface ListVersionMapper {
+  @Mapping(target = "id", source = "listVersion.id")
+  @Mapping(target = "listId", source = "listVersion.listId")
+  @Mapping(target = "name", source = "listVersion.name")
+  @Mapping(target = "description", source = "listVersion.description")
+  @Mapping(target = "userFriendlyQuery", source = "listVersion.userFriendlyQuery")
+  @Mapping(target = "fqlQuery", source = "listVersion.fqlQuery")
+  @Mapping(target = "fields", source = "listVersion.fields")
+  @Mapping(target = "isActive", source = "listVersion.isActive")
+  @Mapping(target = "isPrivate", source = "listVersion.isPrivate")
+  @Mapping(target = "updatedBy", source = "listVersion.updatedBy")
+  @Mapping(target = "updatedByUsername", source = "listVersion.updatedByUsername")
+  @Mapping(target = "updatedDate", source = "listVersion.updatedDate")
+  @Mapping(target = "version", source = "listVersion.version")
+  ListVersionDTO toListVersionDTO(ListVersion listVersion);
+}

--- a/src/main/java/org/folio/list/repository/ListVersionRepository.java
+++ b/src/main/java/org/folio/list/repository/ListVersionRepository.java
@@ -1,0 +1,13 @@
+package org.folio.list.repository;
+
+import org.folio.list.domain.ListVersion;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface ListVersionRepository extends CrudRepository<ListVersion, UUID> {
+  List<ListVersion> findByListId(UUID listId);
+}

--- a/src/main/resources/swagger.api/list.yaml
+++ b/src/main/resources/swagger.api/list.yaml
@@ -359,12 +359,15 @@ paths:
       parameters:
         - $ref: '#/components/parameters/id'
       responses:
-        '201':
+        '200':
           description: 'Getting all the versions of the list'
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListVersionDTO'
+                type: array
+                items:
+                  type:
+                  $ref: "#/components/schemas/ListVersionDTO"
         default:
           description: unexpected error
           content:

--- a/src/test/java/org/folio/list/controller/ListControllerVersionTest.java
+++ b/src/test/java/org/folio/list/controller/ListControllerVersionTest.java
@@ -1,0 +1,74 @@
+package org.folio.list.controller;
+
+import org.folio.list.domain.dto.ListVersionDTO;
+import org.folio.list.exception.ListNotFoundException;
+import org.folio.list.services.ListService;
+import org.folio.list.utils.TestDataFixture;
+import org.folio.spring.integration.XOkapiHeaders;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+
+import static org.folio.spring.integration.XOkapiHeaders.USER_ID;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ListController.class)
+ class ListControllerVersionTest {
+  private static final String TENANT_ID = "test-tenant";
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private ListService listService;
+
+  @Test
+  void testListVersion() throws Exception {
+    UUID listId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    ListVersionDTO listVersionDTO1 = TestDataFixture.getListVersionDTO();
+    ListVersionDTO listVersionDTO2 = TestDataFixture.getListVersionDTO();
+    List<ListVersionDTO> listVersionDTO = List.of(listVersionDTO1, listVersionDTO2);
+
+    var requestBuilder = get("/lists/" + listId + "/versions")
+      .contentType(APPLICATION_JSON)
+      .header(XOkapiHeaders.TENANT, TENANT_ID)
+      .header(USER_ID, userId);
+
+    when(listService.getListVersions(listId)).thenReturn(listVersionDTO);
+    mockMvc.perform(requestBuilder)
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.[0].id", Matchers.is(listVersionDTO1.getId().toString())))
+      .andExpect(jsonPath("$.[0].listId", Matchers.is(listVersionDTO1.getListId().toString())))
+      .andExpect(jsonPath("$.[0].name", Matchers.is(listVersionDTO1.getName())))
+      .andExpect(jsonPath("$.[1].id", Matchers.is(listVersionDTO2.getId().toString())))
+      .andExpect(jsonPath("$.[1].listId", Matchers.is(listVersionDTO2.getListId().toString())))
+      .andExpect(jsonPath("$.[1].name", Matchers.is(listVersionDTO2.getName())));
+  }
+
+  @Test
+  void shouldReturnHttp404WhenListNotFound() throws Exception {
+    var requestBuilder = get("/lists/" + UUID.randomUUID() + "/versions")
+      .contentType(APPLICATION_JSON)
+      .header(XOkapiHeaders.TENANT, TENANT_ID);
+
+    when(listService.getListVersions(UUID.randomUUID()))
+      .thenThrow(ListNotFoundException.class);
+
+    mockMvc.perform(requestBuilder)
+      .andExpect(status().isNotFound())
+      .andExpect(jsonPath("$.code", is("read-list.not.found")));
+  }
+}

--- a/src/test/java/org/folio/list/domain/ListVersionTest.java
+++ b/src/test/java/org/folio/list/domain/ListVersionTest.java
@@ -1,0 +1,26 @@
+package org.folio.list.domain;
+
+import org.folio.list.rest.UsersClient;
+import org.folio.list.utils.TestDataFixture;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ListVersionTest {
+  @Test
+  void shouldSetDataFromListEntity() {
+    ListEntity listEntity = TestDataFixture.getListEntityWithSuccessRefresh();
+    UsersClient.User user = new UsersClient.User(UUID.randomUUID(), Optional.of(new UsersClient.Personal("Test", "User")));
+    ListVersion listVersion = TestDataFixture.getListVersion();
+    listVersion.setDataFromListEntity(listEntity, user);
+    assertEquals(listVersion.getListId(), listEntity.getId());
+    assertEquals(listVersion.getName(), listEntity.getName());
+    assertEquals(listVersion.getFqlQuery(), listEntity.getFqlQuery());
+    assertEquals(listVersion.getIsActive(), listEntity.getIsActive());
+    assertEquals(listVersion.getUpdatedBy(), user.id());
+    assertEquals(listVersion.getUpdatedByUsername(), user.getFullName().get());
+  }
+}

--- a/src/test/java/org/folio/list/mapper/ListVersionMapperTest.java
+++ b/src/test/java/org/folio/list/mapper/ListVersionMapperTest.java
@@ -1,0 +1,31 @@
+package org.folio.list.mapper;
+
+import org.folio.list.domain.ListVersion;
+import org.folio.list.domain.dto.ListVersionDTO;
+import org.folio.list.utils.TestDataFixture;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest(classes = {org.folio.list.mapper.ListVersionMapperImpl.class, MappingMethods.class})
+class ListVersionMapperTest {
+  @Autowired
+  private ListVersionMapper listVersionMapper;
+
+  @Test
+  void shouldMapListVersionToDto() {
+    ListVersion listVersion = TestDataFixture.getListVersion();
+    ListVersionDTO dto = listVersionMapper.toListVersionDTO(listVersion);
+    assertEquals(dto.getId(), listVersion.getId());
+    assertEquals(dto.getListId(), listVersion.getListId());
+    assertEquals(dto.getName(), listVersion.getName());
+    assertEquals(dto.getFqlQuery(), listVersion.getFqlQuery());
+    assertEquals(dto.getIsActive(), listVersion.getIsActive());
+    assertEquals(dto.getVersion(), listVersion.getVersion());
+    assertEquals(dto.getDescription(), listVersion.getDescription());
+    assertEquals(dto.getUpdatedBy(), listVersion.getUpdatedBy());
+    assertEquals(dto.getUpdatedByUsername(), listVersion.getUpdatedByUsername());
+  }
+}

--- a/src/test/java/org/folio/list/utils/TestDataFixture.java
+++ b/src/test/java/org/folio/list/utils/TestDataFixture.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.SneakyThrows;
 import org.folio.list.domain.ExportDetails;
+import org.folio.list.domain.ListVersion;
 import org.folio.list.domain.dto.ListDTO;
 import org.folio.list.domain.dto.ListSummaryDTO;
 import org.folio.list.domain.dto.ListRefreshDTO;
@@ -169,5 +170,17 @@ public class TestDataFixture {
   public static ListExportDTO getListExportDTO() {
     var resource = TestDataFixture.class.getResource("/json/list/list-export-details.json");
     return objectMapper.readValue(resource, ListExportDTO.class);
+  }
+
+  @SneakyThrows
+  public static org.folio.list.domain.dto.ListVersionDTO getListVersionDTO() {
+    var resource = TestDataFixture.class.getResource("/json/list/list-version.json");
+    return objectMapper.readValue(resource, org.folio.list.domain.dto.ListVersionDTO.class);
+  }
+
+  @SneakyThrows
+  public static ListVersion getListVersion() {
+    var resource = TestDataFixture.class.getResource("/json/list/list-version.json");
+    return objectMapper.readValue(resource, ListVersion.class);
   }
 }

--- a/src/test/resources/json/list/list-version.json
+++ b/src/test/resources/json/list/list-version.json
@@ -1,0 +1,14 @@
+{
+  "id": "0cb79a4c-f7eb-4941-a104-745224ae0294",
+  "listId": "0cb79a6c-f7eb-4941-a104-745224ae0292",
+  "name": "Missing Items",
+  "description": "Missing Items List",
+  "fqlQuery": "item_status = 'missing'",
+  "fields": [
+    "id",
+    "item_status"
+  ],
+  "isActive": true,
+  "isPrivate": true,
+  "version": 1
+}


### PR DESCRIPTION
https://issues.folio.org/browse/MODLISTS-61
https://issues.folio.org/browse/MODLISTS-72

This tickets implememts the logic of lists versioning plus we can retrieve the previous versions of lists using get request`lists/{listId}/versions`

<img width="1266" alt="Screen Shot 2023-12-17 at 7 36 42 PM" src="https://github.com/folio-org/mod-lists/assets/114437186/95621aa7-0d96-412a-8877-b348fd686259">
<img width="1283" alt="Screen Shot 2023-12-17 at 7 37 18 PM" src="https://github.com/folio-org/mod-lists/assets/114437186/a4a9ebb4-967e-431b-8408-62a8c686606e">
<img width="1300" alt="Screen Shot 2023-12-17 at 7 38 56 PM" src="https://github.com/folio-org/mod-lists/assets/114437186/4750de08-c00a-4b6c-b95f-799d327e5844">
