### PR TITLE
[MODLISTS-62] Create new list version endpoint

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -46,6 +46,14 @@
           "permissionsRequired": ["lists.item.contents.get"]
         },{
           "methods": ["GET"],
+          "pathPattern": "/lists/{id}/versions",
+          "permissionsRequired": ["lists.item.versions.collection.get"]
+        },{
+          "methods": ["GET"],
+          "pathPattern": "/lists/{id}/versions/{versionNumber}",
+          "permissionsRequired": ["lists.item.versions.item.get"]
+        },{
+          "methods": ["GET"],
           "pathPattern": "/lists/{id}/exports/{exportId}/download",
           "permissionsRequired": ["lists.item.export.download.get"]
         }, {
@@ -148,6 +156,16 @@
       "permissionName": "lists.configuration.get",
       "displayName": "Lists: Get configuration of list application",
       "description": "Get configuration of lists application"
+    },
+    {
+      "permissionName": "lists.item.versions.collection.get",
+      "displayName": "Lists: Get previous versions of a list",
+      "description": "Get the previous versions of a list"
+    },
+    {
+      "permissionName": "lists.item.contents.get",
+      "displayName": "Lists: Get a previous version of a list",
+      "description": "Get a previous version of a list"
     }
   ],
   "requires": [

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -163,7 +163,7 @@
       "description": "Get the previous versions of a list"
     },
     {
-      "permissionName": "lists.item.contents.get",
+      "permissionName": "lists.item.versions.item.get",
       "displayName": "Lists: Get a previous version of a list",
       "description": "Get a previous version of a list"
     }

--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
             </goals>
             <configuration>
               <sources>
-                <source>${project.build.directory}/generated-sources</source>
+                <source>${project.build.directory}/generated-sources/src/main/java</source>
               </sources>
             </configuration>
           </execution>

--- a/src/main/java/org/folio/list/controller/ListController.java
+++ b/src/main/java/org/folio/list/controller/ListController.java
@@ -94,10 +94,11 @@ public class ListController implements ListApi {
 
   @Override
   public ResponseEntity<List<ListVersionDTO>> getListVersions(UUID listId) {
-    var listVersionDto = listService.getListVersions(listId);
-    if (listVersionDto == null || listVersionDto.isEmpty()) {
-      throw new ListNotFoundException(listId, ListActions.READ);
-    }
-    return new ResponseEntity<>(listVersionDto, HttpStatus.OK);
+    return new ResponseEntity<>(listService.getListVersions(listId), HttpStatus.OK);
+  }
+
+  @Override
+  public ResponseEntity<ListVersionDTO> getListVersion(UUID listId, Integer version) {
+    return new ResponseEntity<>(listService.getListVersion(listId, version), HttpStatus.OK);
   }
 }

--- a/src/main/java/org/folio/list/exception/VersionNotFoundException.java
+++ b/src/main/java/org/folio/list/exception/VersionNotFoundException.java
@@ -1,0 +1,62 @@
+package org.folio.list.exception;
+
+import java.util.UUID;
+import org.folio.list.domain.dto.ListAppError;
+import org.folio.list.domain.dto.Parameter;
+import org.folio.list.services.ListActions;
+import org.springframework.http.HttpStatus;
+
+public class VersionNotFoundException extends AbstractListException {
+
+  private static final String ERROR_CODE = "version.not.found";
+  private static final String ERROR_MESSAGE_TEMPLATE =
+    "List (id=%s) does not have a version number %d";
+
+  private final UUID listId;
+  private final int versionNumber;
+  private final ListActions failedAction;
+  private final HttpStatus httpStatus;
+
+  public VersionNotFoundException(
+    UUID listId,
+    int versionNumber,
+    ListActions failedAction
+  ) {
+    this(listId, versionNumber, failedAction, HttpStatus.NOT_FOUND);
+  }
+
+  public VersionNotFoundException(
+    UUID listId,
+    int versionNumber,
+    ListActions failedAction,
+    HttpStatus httpStatus
+  ) {
+    this.listId = listId;
+    this.versionNumber = versionNumber;
+    this.httpStatus = httpStatus;
+    this.failedAction = failedAction;
+  }
+
+  @Override
+  public HttpStatus getHttpStatus() {
+    return httpStatus;
+  }
+
+  @Override
+  public String getMessage() {
+    return String.format(ERROR_MESSAGE_TEMPLATE, listId, versionNumber);
+  }
+
+  @Override
+  public ListAppError getError() {
+    return new ListAppError()
+      .code(getErrorCode(failedAction, ERROR_CODE))
+      .message(getMessage())
+      .addParametersItem(new Parameter().key("id").value(listId.toString()))
+      .addParametersItem(
+        new Parameter()
+          .key("versionNumber")
+          .value(Integer.toString(versionNumber))
+      );
+  }
+}

--- a/src/main/java/org/folio/list/repository/ListVersionRepository.java
+++ b/src/main/java/org/folio/list/repository/ListVersionRepository.java
@@ -1,13 +1,15 @@
 package org.folio.list.repository;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import org.folio.list.domain.ListVersion;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.UUID;
-
 @Repository
-public interface ListVersionRepository extends CrudRepository<ListVersion, UUID> {
+public interface ListVersionRepository
+  extends CrudRepository<ListVersion, UUID> {
   List<ListVersion> findByListId(UUID listId);
+  Optional<ListVersion> findByListIdAndVersion(UUID listId, int version);
 }

--- a/src/main/java/org/folio/list/services/ListValidationService.java
+++ b/src/main/java/org/folio/list/services/ListValidationService.java
@@ -64,7 +64,6 @@ public class ListValidationService {
 
   public void assertSharedOrOwnedByUser(ListEntity list, ListActions failedAction) {
     UUID currentOwnerId = (list.getUpdatedBy() == null) ? list.getCreatedBy() : list.getUpdatedBy();
-    System.out.println(folioExecutionContext.getUserId());
     if (Boolean.TRUE.equals(list.getIsPrivate()) && ! currentOwnerId.equals(folioExecutionContext.getUserId())) {
       throw new PrivateListOfAnotherUserException(list, failedAction);
     }

--- a/src/main/java/org/folio/list/services/ListValidationService.java
+++ b/src/main/java/org/folio/list/services/ListValidationService.java
@@ -64,6 +64,7 @@ public class ListValidationService {
 
   public void assertSharedOrOwnedByUser(ListEntity list, ListActions failedAction) {
     UUID currentOwnerId = (list.getUpdatedBy() == null) ? list.getCreatedBy() : list.getUpdatedBy();
+    System.out.println(folioExecutionContext.getUserId());
     if (Boolean.TRUE.equals(list.getIsPrivate()) && ! currentOwnerId.equals(folioExecutionContext.getUserId())) {
       throw new PrivateListOfAnotherUserException(list, failedAction);
     }

--- a/src/main/resources/swagger.api/list.yaml
+++ b/src/main/resources/swagger.api/list.yaml
@@ -355,12 +355,12 @@ paths:
       operationId: getListVersions
       tags:
         - list
-      description: Get all the versions of the specified list.
+      description: Get all the historic versions of the specified list.
       parameters:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
-          description: 'Getting all the versions of the list'
+          description: 'Getting all the historic versions of the list'
           content:
             application/json:
               schema:
@@ -379,13 +379,13 @@ paths:
       operationId: getListVersion
       tags:
         - list
-      description: Get a specific version of the specified list.
+      description: Get a specific historic version of the specified list.
       parameters:
         - $ref: '#/components/parameters/id'
         - $ref: '#/components/parameters/versionNumber'
       responses:
         '200':
-          description: 'Get the requested list version'
+          description: 'Get the requested historic list version'
           content:
             application/json:
               schema:

--- a/src/main/resources/swagger.api/list.yaml
+++ b/src/main/resources/swagger.api/list.yaml
@@ -374,6 +374,34 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ListAppError"
+  /lists/{id}/versions/{versionNumber}:
+    get:
+      operationId: getListVersion
+      tags:
+        - list
+      description: Get a specific version of the specified list.
+      parameters:
+        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/versionNumber'
+      responses:
+        '200':
+          description: 'Get the requested list version'
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListVersionDTO"
+        '404':
+          description: List or version not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListAppError"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListAppError"
 components:
   parameters:
     id:
@@ -392,6 +420,14 @@ components:
       schema:
         type: string
         format: UUID
+    versionNumber:
+      name: versionNumber
+      in: path
+      required: true
+      description: Integer number of the requested version
+      schema:
+        type: integer
+        minimum: 1
   schemas:
     ListDTO:
       $ref: schemas/ListDTO.json

--- a/src/test/java/org/folio/list/controller/ListControllerVersionTest.java
+++ b/src/test/java/org/folio/list/controller/ListControllerVersionTest.java
@@ -1,5 +1,15 @@
 package org.folio.list.controller;
 
+import static org.folio.spring.integration.XOkapiHeaders.USER_ID;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.UUID;
 import org.folio.list.domain.dto.ListVersionDTO;
 import org.folio.list.exception.ListNotFoundException;
 import org.folio.list.services.ListService;
@@ -12,20 +22,9 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.List;
-import java.util.UUID;
-
-
-import static org.folio.spring.integration.XOkapiHeaders.USER_ID;
-import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.when;
-import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 @WebMvcTest(ListController.class)
- class ListControllerVersionTest {
+class ListControllerVersionTest {
+
   private static final String TENANT_ID = "test-tenant";
 
   @Autowired
@@ -40,7 +39,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     UUID userId = UUID.randomUUID();
     ListVersionDTO listVersionDTO1 = TestDataFixture.getListVersionDTO();
     ListVersionDTO listVersionDTO2 = TestDataFixture.getListVersionDTO();
-    List<ListVersionDTO> listVersionDTO = List.of(listVersionDTO1, listVersionDTO2);
+    List<ListVersionDTO> listVersionDTO = List.of(
+      listVersionDTO1,
+      listVersionDTO2
+    );
 
     var requestBuilder = get("/lists/" + listId + "/versions")
       .contentType(APPLICATION_JSON)
@@ -48,14 +50,31 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
       .header(USER_ID, userId);
 
     when(listService.getListVersions(listId)).thenReturn(listVersionDTO);
-    mockMvc.perform(requestBuilder)
+    mockMvc
+      .perform(requestBuilder)
       .andExpect(status().isOk())
-      .andExpect(jsonPath("$.[0].id", Matchers.is(listVersionDTO1.getId().toString())))
-      .andExpect(jsonPath("$.[0].listId", Matchers.is(listVersionDTO1.getListId().toString())))
+      .andExpect(
+        jsonPath("$.[0].id", Matchers.is(listVersionDTO1.getId().toString()))
+      )
+      .andExpect(
+        jsonPath(
+          "$.[0].listId",
+          Matchers.is(listVersionDTO1.getListId().toString())
+        )
+      )
       .andExpect(jsonPath("$.[0].name", Matchers.is(listVersionDTO1.getName())))
-      .andExpect(jsonPath("$.[1].id", Matchers.is(listVersionDTO2.getId().toString())))
-      .andExpect(jsonPath("$.[1].listId", Matchers.is(listVersionDTO2.getListId().toString())))
-      .andExpect(jsonPath("$.[1].name", Matchers.is(listVersionDTO2.getName())));
+      .andExpect(
+        jsonPath("$.[1].id", Matchers.is(listVersionDTO2.getId().toString()))
+      )
+      .andExpect(
+        jsonPath(
+          "$.[1].listId",
+          Matchers.is(listVersionDTO2.getListId().toString())
+        )
+      )
+      .andExpect(
+        jsonPath("$.[1].name", Matchers.is(listVersionDTO2.getName()))
+      );
   }
 
   @Test
@@ -67,7 +86,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     when(listService.getListVersions(UUID.randomUUID()))
       .thenThrow(ListNotFoundException.class);
 
-    mockMvc.perform(requestBuilder)
+    mockMvc
+      .perform(requestBuilder)
       .andExpect(status().isNotFound())
       .andExpect(jsonPath("$.code", is("read-list.not.found")));
   }

--- a/src/test/java/org/folio/list/controller/ListControllerVersionTest.java
+++ b/src/test/java/org/folio/list/controller/ListControllerVersionTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.UUID;
 import org.folio.list.domain.dto.ListVersionDTO;
 import org.folio.list.exception.ListNotFoundException;
+import org.folio.list.services.ListActions;
 import org.folio.list.services.ListService;
 import org.folio.list.utils.TestDataFixture;
 import org.folio.spring.integration.XOkapiHeaders;
@@ -27,6 +28,9 @@ class ListControllerVersionTest {
 
   private static final String TENANT_ID = "test-tenant";
 
+  private static final UUID TEST_LIST_ID = UUID.fromString("ca08e0e4-ceef-5456-821f-b44309f0f77e");
+  private static final UUID TEST_USER_ID = UUID.fromString("f3ed39d2-b0da-571a-9917-0e6d31e144aa");
+
   @Autowired
   private MockMvc mockMvc;
 
@@ -35,8 +39,6 @@ class ListControllerVersionTest {
 
   @Test
   void testListVersion() throws Exception {
-    UUID listId = UUID.randomUUID();
-    UUID userId = UUID.randomUUID();
     ListVersionDTO listVersionDTO1 = TestDataFixture.getListVersionDTO();
     ListVersionDTO listVersionDTO2 = TestDataFixture.getListVersionDTO();
     List<ListVersionDTO> listVersionDTO = List.of(
@@ -44,12 +46,12 @@ class ListControllerVersionTest {
       listVersionDTO2
     );
 
-    var requestBuilder = get("/lists/" + listId + "/versions")
+    var requestBuilder = get("/lists/" + TEST_LIST_ID + "/versions")
       .contentType(APPLICATION_JSON)
       .header(XOkapiHeaders.TENANT, TENANT_ID)
-      .header(USER_ID, userId);
+      .header(USER_ID, TEST_USER_ID);
 
-    when(listService.getListVersions(listId)).thenReturn(listVersionDTO);
+    when(listService.getListVersions(TEST_LIST_ID)).thenReturn(listVersionDTO);
     mockMvc
       .perform(requestBuilder)
       .andExpect(status().isOk())
@@ -78,13 +80,13 @@ class ListControllerVersionTest {
   }
 
   @Test
-  void shouldReturnHttp404WhenListNotFound() throws Exception {
-    var requestBuilder = get("/lists/" + UUID.randomUUID() + "/versions")
+  void testListsVersionsNotFound() throws Exception {
+    var requestBuilder = get("/lists/" + TEST_LIST_ID + "/versions")
       .contentType(APPLICATION_JSON)
       .header(XOkapiHeaders.TENANT, TENANT_ID);
 
-    when(listService.getListVersions(UUID.randomUUID()))
-      .thenThrow(ListNotFoundException.class);
+    when(listService.getListVersions(TEST_LIST_ID))
+      .thenThrow(new ListNotFoundException(TEST_LIST_ID, ListActions.READ));
 
     mockMvc
       .perform(requestBuilder)

--- a/src/test/java/org/folio/list/service/ListServiceTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceTest.java
@@ -49,7 +49,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -311,6 +310,11 @@ class ListServiceTest {
     assertThat(user.getFullName()).contains(entity.getUpdatedByUsername());
     assertThat(entity.getVersion()).isEqualTo(previousVersion + 1);
     assertThat(entity.getUserFriendlyQuery()).isEqualTo(userFriendlyQuery);
+
+    // ensure we saved the previous version correctly
+    ArgumentCaptor<ListVersion> oldVersion = ArgumentCaptor.forClass(ListVersion.class);
+    verify(listVersionRepository, times(1)).save(oldVersion.capture());
+    assertThat(oldVersion.getValue().getVersion()).isEqualTo(previousVersion);
   }
 
   // This test can be removed once the UI has been updated to allow fields to be sent in the list update request


### PR DESCRIPTION
# [Jira MODLISTS-62](https://issues.folio.org/browse/MODLISTS-62)

## Purpose
Create an endpoint to `GET` a single version of a list

## Approach
- Extend existing repository/service/controllers to support a new endpoint.

## ✨ Bonus ✨
- Moved logic to ensure a list exists for `/lists/{id}/versions` into the Service rather than the Controller
- Fixed error where a list with no versions (possible after creation) would throw an exception
- Added tests to ensure that we actually save a list's old version when updating (not a super-rigorous test, but better than nothing)
  - Will do more in Karate as part of [Jira FAT-10223](https://issues.folio.org/browse/FAT-10223)
