### PR TITLE
[MODLISTS-74] Delete list versions automatically with parent list

### DIFF
--- a/src/main/resources/db/changelog/changes/v1.1.0/changelog-v1.1.0.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/changelog-v1.1.0.xml
@@ -5,4 +5,5 @@
                     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
 
   <include file="sql/create-list-versions-table.sql" relativeToChangelogFile="true"/>
+  <include file="yml/update-list-versions-fkey.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.1.0/yml/update-list-versions-fkey.yaml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/yml/update-list-versions-fkey.yaml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: update-list-versions-fkey
+      author: novercash@ebsco.com
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: list_versions
+            constraintName: fk_report_id
+        - addForeignKeyConstraint:
+            constraintName: fk_list_id
+            baseTableName: list_versions
+            baseColumnNames: list_id
+            referencedTableName: list_details
+            referencedColumnNames: id
+            onDelete: CASCADE


### PR DESCRIPTION
# [Jira MODLISTS-74](https://issues.folio.org/browse/MODLISTS-74)

## Purpose
The new `list_versions` table enforced a foreign key constraint which disallowed deletion of the parent entity (lists). This made it impossible to delete lists.

## Approach
Updates the foreign key constraint to `CASCADE` on deletions.
