### PR TITLE
[MODLISTS-75] Source version author information from list rather than session

### DIFF
--- a/src/main/java/org/folio/list/domain/ListVersion.java
+++ b/src/main/java/org/folio/list/domain/ListVersion.java
@@ -1,18 +1,19 @@
 package org.folio.list.domain;
 
-import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
-
-import org.folio.list.rest.UsersClient.User;
-
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Entity
@@ -66,7 +67,6 @@ public class ListVersion {
   @NotNull
   private Boolean isPrivate;
 
-
   @Column(name = "version")
   @NotNull
   private int version;
@@ -74,19 +74,18 @@ public class ListVersion {
   @Column(name = "user_friendly_query")
   private String userFriendlyQuery;
 
-  public void setDataFromListEntity(ListEntity listEntity, User user) {
+  public void setDataFromListEntity(ListEntity listEntity) {
     listId = listEntity.getId();
     name = listEntity.getName();
     fqlQuery = listEntity.getFqlQuery();
     description = listEntity.getDescription();
     userFriendlyQuery = listEntity.getUserFriendlyQuery();
     fields = listEntity.getFields();
-    updatedBy = user.id();
-    updatedByUsername = user.getFullName().orElse(user.id().toString());
-    updatedDate = OffsetDateTime.now();
+    updatedBy = listEntity.getUpdatedBy();
+    updatedByUsername = listEntity.getUpdatedByUsername();
+    updatedDate = listEntity.getUpdatedDate();
     version = listEntity.getVersion();
     isActive = listEntity.getIsActive();
     isPrivate = listEntity.getIsPrivate();
   }
-
 }

--- a/src/main/java/org/folio/list/mapper/ListEntityMapper.java
+++ b/src/main/java/org/folio/list/mapper/ListEntityMapper.java
@@ -18,6 +18,9 @@ public interface ListEntityMapper {
   @Mapping(target = "createdDate", expression = "java(java.time.OffsetDateTime.now())")
   @Mapping(target = "createdBy", expression = "java(createdBy.id())")
   @Mapping(target = "createdByUsername", expression = "java(createdBy.getFullName().orElse(createdBy.id().toString()))")
+  @Mapping(target = "updatedDate", expression = "java(java.time.OffsetDateTime.now())")
+  @Mapping(target = "updatedBy", expression = "java(createdBy.id())")
+  @Mapping(target = "updatedByUsername", expression = "java(createdBy.getFullName().orElse(createdBy.id().toString()))")
   @Mapping(target = "isCanned", constant = "false")
   @Mapping(target = "version", constant = "1")
   ListEntity toListEntity(ListRequestDTO request, UsersClient.User createdBy);

--- a/src/main/java/org/folio/list/services/ListService.java
+++ b/src/main/java/org/folio/list/services/ListService.java
@@ -128,8 +128,8 @@ public class ListService {
     Optional<ListEntity> listEntity = listRepository.findById(id);
     listEntity.ifPresent(list -> {
       ListVersion previousVersions = new ListVersion();
-      previousVersions.setDataFromListEntity(listEntity.get(), getCurrentUser());
-      listVersionRepository.save(previousVersions);
+      previousVersions.setDataFromListEntity(listEntity.get());
+
       EntityType entityType = getEntityType(list.getEntityTypeId());
       validationService.validateUpdate(list, request, entityType);
       if (!request.getIsActive()) {
@@ -153,6 +153,8 @@ public class ListService {
         timer.start(TimedStage.TOTAL);
         importListContentsFromAsyncQuery(list, getCurrentUser(), request.getQueryId(), timer);
       }
+
+      listVersionRepository.save(previousVersions);
       listRepository.save(list);
     });
 

--- a/src/main/java/org/folio/list/services/ListService.java
+++ b/src/main/java/org/folio/list/services/ListService.java
@@ -128,7 +128,7 @@ public class ListService {
     Optional<ListEntity> listEntity = listRepository.findById(id);
     listEntity.ifPresent(list -> {
       ListVersion previousVersions = new ListVersion();
-      previousVersions.setDataFromListEntity(listEntity.get());
+      previousVersions.setDataFromListEntity(list);
 
       EntityType entityType = getEntityType(list.getEntityTypeId());
       validationService.validateUpdate(list, request, entityType);

--- a/src/main/resources/db/changelog/changes/v1.1.0/changelog-v1.1.0.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/changelog-v1.1.0.xml
@@ -6,4 +6,5 @@
 
   <include file="sql/create-list-versions-table.sql" relativeToChangelogFile="true"/>
   <include file="yml/update-list-versions-fkey.yaml" relativeToChangelogFile="true"/>
+  <include file="yml/alter-list-details-updated-metadata-add-not-null-constraint.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.1.0/yml/alter-list-details-updated-metadata-add-not-null-constraint.yaml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/yml/alter-list-details-updated-metadata-add-not-null-constraint.yaml
@@ -1,0 +1,29 @@
+databaseChangeLog:
+  - changeSet:
+      id: alter-list-details-updated-metadata-add-not-null-constraint
+      author: novercash@ebsco.com
+      changes:
+        # backfill default values
+        - addDefaultValue:
+            tableName: list_details
+            columnName: updated_by
+            defaultValueComputed: created_by
+        - addDefaultValue:
+            tableName: list_details
+            columnName: updated_by_username
+            defaultValueComputed: created_by_username
+        - addDefaultValue:
+            tableName: list_details
+            columnName: updated_date
+            defaultValueComputed: created_date
+
+        # add new constraints
+        - addNotNullConstraint:
+            columnName: updated_by
+            tableName: list_details
+        - addNotNullConstraint:
+            columnName: updated_by_username
+            tableName: list_details
+        - addNotNullConstraint:
+            columnName: updated_date
+            tableName: list_details

--- a/src/main/resources/db/changelog/changes/v1.1.0/yml/alter-list-details-updated-metadata-add-not-null-constraint.yaml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/yml/alter-list-details-updated-metadata-add-not-null-constraint.yaml
@@ -4,18 +4,19 @@ databaseChangeLog:
       author: novercash@ebsco.com
       changes:
         # backfill default values
-        - addDefaultValue:
+        - update:
             tableName: list_details
-            columnName: updated_by
-            defaultValueComputed: created_by
-        - addDefaultValue:
-            tableName: list_details
-            columnName: updated_by_username
-            defaultValueComputed: created_by_username
-        - addDefaultValue:
-            tableName: list_details
-            columnName: updated_date
-            defaultValueComputed: created_date
+            columns:
+              - column:
+                  name: updated_by
+                  valueComputed: created_by
+              - column:
+                  name: updated_by_username
+                  valueComputed: created_by_username
+              - column:
+                  name: updated_date
+                  valueComputed: created_date
+            where: updated_by IS NULL
 
         # add new constraints
         - addNotNullConstraint:

--- a/src/test/java/org/folio/list/domain/ListVersionTest.java
+++ b/src/test/java/org/folio/list/domain/ListVersionTest.java
@@ -1,26 +1,25 @@
 package org.folio.list.domain;
 
-import org.folio.list.rest.UsersClient;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.folio.list.utils.TestDataFixture;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
-import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 class ListVersionTest {
+
   @Test
   void shouldSetDataFromListEntity() {
     ListEntity listEntity = TestDataFixture.getListEntityWithSuccessRefresh();
-    UsersClient.User user = new UsersClient.User(UUID.randomUUID(), Optional.of(new UsersClient.Personal("Test", "User")));
     ListVersion listVersion = TestDataFixture.getListVersion();
-    listVersion.setDataFromListEntity(listEntity, user);
+    listVersion.setDataFromListEntity(listEntity);
     assertEquals(listVersion.getListId(), listEntity.getId());
     assertEquals(listVersion.getName(), listEntity.getName());
     assertEquals(listVersion.getFqlQuery(), listEntity.getFqlQuery());
     assertEquals(listVersion.getIsActive(), listEntity.getIsActive());
-    assertEquals(listVersion.getUpdatedBy(), user.id());
-    assertEquals(listVersion.getUpdatedByUsername(), user.getFullName().get());
+    assertEquals(listVersion.getUpdatedBy(), listEntity.getUpdatedBy());
+    assertEquals(
+      listVersion.getUpdatedByUsername(),
+      listEntity.getUpdatedByUsername()
+    );
   }
 }


### PR DESCRIPTION
# [Jira MODLISTS-75](https://issues.folio.org/browse/MODLISTS-75)

## Purpose
List version metadata (created by/timestamp) was sourced from the current user/time, however, we should store the list's previous updated information instead.  This will ensure that, when User A's changes get persisted as a historical version (i.e. the list is updated in the future), user A's information and original time get persisted, too. 

## Approach
Alter list version logic