### PR TITLE
[MODLISTS-71] Soft deletion within lists

### DIFF
--- a/src/main/java/org/folio/list/controller/ListController.java
+++ b/src/main/java/org/folio/list/controller/ListController.java
@@ -1,5 +1,9 @@
 package org.folio.list.controller;
 
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.folio.list.domain.dto.ListDTO;
 import org.folio.list.domain.dto.ListRefreshDTO;
@@ -19,11 +23,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
-import java.util.UUID;
-
 @RequiredArgsConstructor
 @RestController
 public class ListController implements ListApi {
@@ -31,19 +30,35 @@ public class ListController implements ListApi {
   private final ListService listService;
 
   @Override
-  public ResponseEntity<ListSummaryResultsDTO> getAllLists(List<UUID> ids,
-                                                           List<UUID> entityTypeIds,
-                                                           Integer offset,
-                                                           Integer size, Boolean active,
-                                                           Boolean isPrivate, // Note: query param name is "private"
-                                                           String updatedAsOf
+  public ResponseEntity<ListSummaryResultsDTO> getAllLists(
+    List<UUID> ids,
+    List<UUID> entityTypeIds,
+    Integer offset,
+    Integer size,
+    Boolean active,
+    Boolean isPrivate, // Note: query param name is "private"
+    Boolean includeDeleted,
+    String updatedAsOf
   ) {
     OffsetDateTime providedTimestamp;
     DateTimeFormatter formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
     // In the backend, the plus sign (+) that is received through RequestParams within the provided timestamp gets substituted with a blank space.
-    providedTimestamp = !StringUtils.hasText(updatedAsOf) ? null : OffsetDateTime.parse(updatedAsOf.replace(' ', '+'), formatter);
+    providedTimestamp =
+      !StringUtils.hasText(updatedAsOf)
+        ? null
+        : OffsetDateTime.parse(updatedAsOf.replace(' ', '+'), formatter);
     Pageable pageable = new OffsetRequest(offset, size);
-    return ResponseEntity.ok(listService.getAllLists(pageable, ids, entityTypeIds, active, isPrivate, providedTimestamp));
+    return ResponseEntity.ok(
+      listService.getAllLists(
+        pageable,
+        ids,
+        entityTypeIds,
+        active,
+        isPrivate,
+        includeDeleted,
+        providedTimestamp
+      )
+    );
   }
 
   @Override
@@ -53,29 +68,40 @@ public class ListController implements ListApi {
   }
 
   @Override
-  public ResponseEntity<ListDTO> updateList(UUID id, ListUpdateRequestDTO listUpdateRequest) {
-    return listService.updateList(id, listUpdateRequest)
+  public ResponseEntity<ListDTO> updateList(
+    UUID id,
+    ListUpdateRequestDTO listUpdateRequest
+  ) {
+    return listService
+      .updateList(id, listUpdateRequest)
       .map(ResponseEntity::ok)
       .orElseThrow(() -> new ListNotFoundException(id, ListActions.UPDATE));
   }
 
   @Override
   public ResponseEntity<ListDTO> getListById(UUID id) {
-    return listService.getListById(id)
+    return listService
+      .getListById(id)
       .map(ResponseEntity::ok)
       .orElseThrow(() -> new ListNotFoundException(id, ListActions.READ));
   }
 
   @Override
   public ResponseEntity<ListRefreshDTO> performRefresh(UUID id) {
-    return listService.performRefresh(id)
+    return listService
+      .performRefresh(id)
       .map(ResponseEntity::ok)
       .orElseThrow(() -> new ListNotFoundException(id, ListActions.REFRESH));
   }
 
   @Override
-  public ResponseEntity<ResultsetPage> getListContents(UUID id, Integer offset, Integer size) {
-    return listService.getListContents(id, offset, size)
+  public ResponseEntity<ResultsetPage> getListContents(
+    UUID id,
+    Integer offset,
+    Integer size
+  ) {
+    return listService
+      .getListContents(id, offset, size)
       .map(ResponseEntity::ok)
       .orElseThrow(() -> new ListNotFoundException(id, ListActions.READ));
   }
@@ -94,11 +120,20 @@ public class ListController implements ListApi {
 
   @Override
   public ResponseEntity<List<ListVersionDTO>> getListVersions(UUID listId) {
-    return new ResponseEntity<>(listService.getListVersions(listId), HttpStatus.OK);
+    return new ResponseEntity<>(
+      listService.getListVersions(listId),
+      HttpStatus.OK
+    );
   }
 
   @Override
-  public ResponseEntity<ListVersionDTO> getListVersion(UUID listId, Integer version) {
-    return new ResponseEntity<>(listService.getListVersion(listId, version), HttpStatus.OK);
+  public ResponseEntity<ListVersionDTO> getListVersion(
+    UUID listId,
+    Integer version
+  ) {
+    return new ResponseEntity<>(
+      listService.getListVersion(listId, version),
+      HttpStatus.OK
+    );
   }
 }

--- a/src/main/java/org/folio/list/domain/ListEntity.java
+++ b/src/main/java/org/folio/list/domain/ListEntity.java
@@ -18,12 +18,15 @@ import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.With;
+
 import org.folio.list.domain.dto.ListUpdateRequestDTO;
 import org.folio.list.exception.AbstractListException;
 import org.folio.list.rest.UsersClient.User;
 import org.folio.list.util.TaskTimer;
 
 @Data
+@With
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
@@ -101,11 +104,14 @@ public class ListEntity {
   private ListRefreshDetails failedRefresh;
 
   @Column(name = "version")
-  @NotNull
   private int version;
 
   @Column(name = "user_friendly_query")
   private String userFriendlyQuery;
+
+  @Column(name = "is_deleted")
+  @NotNull
+  private Boolean isDeleted;
 
   public boolean isRefreshing() {
     return inProgressRefresh != null;

--- a/src/main/java/org/folio/list/mapper/ListEntityMapper.java
+++ b/src/main/java/org/folio/list/mapper/ListEntityMapper.java
@@ -22,6 +22,7 @@ public interface ListEntityMapper {
   @Mapping(target = "updatedBy", expression = "java(createdBy.id())")
   @Mapping(target = "updatedByUsername", expression = "java(createdBy.getFullName().orElse(createdBy.id().toString()))")
   @Mapping(target = "isCanned", constant = "false")
+  @Mapping(target = "isDeleted", constant = "false")
   @Mapping(target = "version", constant = "1")
   ListEntity toListEntity(ListRequestDTO request, UsersClient.User createdBy);
 }

--- a/src/main/java/org/folio/list/repository/ListRepository.java
+++ b/src/main/java/org/folio/list/repository/ListRepository.java
@@ -27,6 +27,7 @@ public interface ListRepository extends CrudRepository<ListEntity, UUID>, Paging
       AND (l.isPrivate = false OR l.updatedBy = :currentUserId OR ( l.updatedBy IS NULL AND l.createdBy = :currentUserId))
       AND (:isPrivate IS NULL OR l.isPrivate = :isPrivate)
       AND (:active IS NULL OR l.isActive = :active)
+      AND (:includeDeleted IS NULL OR :includeDeleted = true OR l.isDeleted = false)
       AND (TO_TIMESTAMP(CAST(:updatedAsOf AS text), 'YYYY-MM-DD HH24:MI:SS.MS') IS NULL OR
       (l.createdDate>= TO_TIMESTAMP(CAST(:updatedAsOf AS text), 'YYYY-MM-DD HH24:MI:SS.MS') OR
       l.updatedDate>= TO_TIMESTAMP(CAST(:updatedAsOf AS text), 'YYYY-MM-DD HH24:MI:SS.MS')))

--- a/src/main/java/org/folio/list/repository/ListRepository.java
+++ b/src/main/java/org/folio/list/repository/ListRepository.java
@@ -10,10 +10,13 @@ import org.springframework.stereotype.Repository;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface ListRepository extends CrudRepository<ListEntity, UUID>, PagingAndSortingRepository<ListEntity, UUID> {
+
+  Optional<ListEntity> findByIdAndIsDeletedFalse(UUID id);
 
   @Query(
     value = """
@@ -37,12 +40,22 @@ public interface ListRepository extends CrudRepository<ListEntity, UUID>, Paging
       AND (l.isPrivate = false OR l.updatedBy = :currentUserId OR ( l.updatedBy IS NULL AND l.createdBy = :currentUserId))
       AND (:isPrivate IS NULL OR l.isPrivate = :isPrivate)
       AND (:active IS NULL OR l.isActive = :active)
+      AND (:includeDeleted IS NULL OR :includeDeleted = true OR l.isDeleted = false)
       AND (TO_TIMESTAMP(CAST(:updatedAsOf AS text), 'YYYY-MM-DD HH24:MI:SS.MS') IS NULL OR
       (l.createdDate>= TO_TIMESTAMP(CAST(:updatedAsOf AS text), 'YYYY-MM-DD HH24:MI:SS.MS') OR
       l.updatedDate>= TO_TIMESTAMP(CAST(:updatedAsOf AS text), 'YYYY-MM-DD HH24:MI:SS.MS')))
        """
- )
-  Page<ListEntity> searchList(Pageable pageable, List<UUID> ids, List<UUID> entityTypeIds, UUID currentUserId, Boolean active, Boolean isPrivate, OffsetDateTime updatedAsOf);
+  )
+  Page<ListEntity> searchList(
+    Pageable pageable,
+    List<UUID> ids,
+    List<UUID> entityTypeIds,
+    UUID currentUserId,
+    Boolean active,
+    Boolean isPrivate,
+    Boolean includeDeleted,
+    OffsetDateTime updatedAsOf
+  );
 
 }
 

--- a/src/main/java/org/folio/list/services/export/ListExportService.java
+++ b/src/main/java/org/folio/list/services/export/ListExportService.java
@@ -44,7 +44,7 @@ public class ListExportService {
 
   @Transactional
   public ListExportDTO createExport(UUID listId) {
-    ListEntity list = listRepository.findById(listId)
+    ListEntity list = listRepository.findByIdAndIsDeletedFalse(listId)
       .orElseThrow(() -> new ListNotFoundException(listId, ListActions.EXPORT));
     validationService.validateCreateExport(list);
     ExportDetails exportDetails = createExportDetails(list);

--- a/src/main/java/org/folio/list/services/refresh/RefreshFailedCallback.java
+++ b/src/main/java/org/folio/list/services/refresh/RefreshFailedCallback.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
-import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 
 @Service
@@ -51,7 +50,7 @@ public class RefreshFailedCallback {
    * inProgressRefreshId for this list in database.
    */
   private boolean isActiveRefresh(UUID listId, UUID refreshId) {
-    return listRepository.findById(listId)
+    return listRepository.findByIdAndIsDeletedFalse(listId)
       .flatMap(ListEntity::getInProgressRefreshId)
       .filter(Predicate.isEqual(refreshId))
       .isPresent();

--- a/src/main/java/org/folio/list/services/refresh/RefreshSuccessCallback.java
+++ b/src/main/java/org/folio/list/services/refresh/RefreshSuccessCallback.java
@@ -56,7 +56,7 @@ public class RefreshSuccessCallback implements SuccessCallback {
    * inProgressRefreshId for this list in database.
    */
   private boolean isActiveRefresh(UUID listId, UUID refreshId) {
-    return listRepository.findById(listId)
+    return listRepository.findByIdAndIsDeletedFalse(listId)
       .flatMap(ListEntity::getInProgressRefreshId)
       .filter(Predicate.isEqual(refreshId))
       .isPresent();

--- a/src/main/resources/db/changelog/changes/v1.1.0/changelog-v1.1.0.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/changelog-v1.1.0.xml
@@ -8,4 +8,5 @@
   <include file="yml/update-list-versions-fkey.yaml" relativeToChangelogFile="true"/>
   <include file="yml/alter-list-details-updated-metadata-add-not-null-constraint.yaml" relativeToChangelogFile="true"/>
   <include file="sql/update-list-refresh-details-table.sql" relativeToChangelogFile="true"/>
+  <include file="yml/add-list-details-is-deleted-column.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.1.0/yml/add-list-details-is-deleted-column.yaml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/yml/add-list-details-is-deleted-column.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-list-details-is-deleted-column
+      author: novercash@ebsco.com
+      changes:
+        - addColumn:
+            tableName: list_details
+            columns:
+              - column:
+                  name: is_deleted
+                  type: boolean
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false

--- a/src/main/resources/swagger.api/list.yaml
+++ b/src/main/resources/swagger.api/list.yaml
@@ -57,6 +57,12 @@ paths:
           required: false
           schema:
             type: boolean
+        - name: includeDeleted
+          in: query
+          description: Indicates if deleted lists should be included in the results (default false)
+          required: false
+          schema:
+            type: boolean
         - name: updatedAsOf
           in: query
           description: Indicates the minimum create/update timestamp to filter lists by

--- a/src/main/resources/swagger.api/schemas/ListDTO.json
+++ b/src/main/resources/swagger.api/schemas/ListDTO.json
@@ -66,6 +66,10 @@
       "description": "Indicates if a List is canned or not",
       "type": "boolean"
     },
+    "isDeleted" : {
+      "description": "Indicates if a List has been deleted",
+      "type": "boolean"
+    },
     "updatedBy": {
       "description": "ID of the user who last updated the record (when available)",
       "type": "string",

--- a/src/main/resources/swagger.api/schemas/ListSummaryResultsDTO.json
+++ b/src/main/resources/swagger.api/schemas/ListSummaryResultsDTO.json
@@ -69,6 +69,10 @@
         "description": "Indicates if a List is canned or not",
         "type": "boolean"
       },
+      "isDeleted" : {
+        "description": "Indicates if a List has been deleted",
+        "type": "boolean"
+      },
       "updatedBy": {
         "description": "ID of the user who last updated the record (when available)",
         "type": "string",

--- a/src/test/java/org/folio/list/controller/ListControllerGetListsTest.java
+++ b/src/test/java/org/folio/list/controller/ListControllerGetListsTest.java
@@ -54,7 +54,7 @@ class ListControllerGetListsTest {
       .contentType(APPLICATION_JSON)
       .header(XOkapiHeaders.TENANT, TENANT_ID);
 
-    when(listService.getAllLists(any(Pageable.class), Mockito.eq(null),
+    when(listService.getAllLists(any(Pageable.class), Mockito.eq(null), Mockito.eq(null),
      Mockito.eq(null), Mockito.eq(null), Mockito.eq(null), Mockito.eq(null))).thenReturn(listSummaryResultsDto);
 
     mockMvc.perform(requestBuilder)
@@ -87,11 +87,12 @@ class ListControllerGetListsTest {
       .queryParam("entityTypeIds", listDto1.getEntityTypeId().toString(), listDto2.getEntityTypeId().toString())
       .queryParam("active", "true")
       .queryParam("private", "true")
+      .queryParam("includeDeleted", "false")
       .queryParam("updatedAsOf", "2023-01-27T20:54:41.528281+05:30");
 
 
     when(listService.getAllLists(any(Pageable.class), Mockito.eq(listIds),
-      Mockito.eq(listEntityIds), Mockito.eq(true), Mockito.eq(true), Mockito.eq(providedTimestamp)))
+      Mockito.eq(listEntityIds), Mockito.eq(true), Mockito.eq(true), Mockito.eq(false), Mockito.eq(providedTimestamp)))
       .thenReturn(listSummaryResultsDto);
 
     mockMvc.perform(requestBuilder)
@@ -127,7 +128,7 @@ class ListControllerGetListsTest {
       .queryParam("private", "false");
 
     when(listService.getAllLists(pageable, null,
-      null, false, false, null)).thenReturn(listSummaryResultsDto);
+      null, false, false, null, null)).thenReturn(listSummaryResultsDto);
 
     mockMvc.perform(requestBuilder)
       .andExpect(status().isOk())

--- a/src/test/java/org/folio/list/service/ListServiceCancelRefreshTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceCancelRefreshTest.java
@@ -1,5 +1,10 @@
 package org.folio.list.service;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+import java.util.UUID;
 import org.folio.list.domain.AsyncProcessStatus;
 import org.folio.list.domain.ListEntity;
 import org.folio.list.domain.ListRefreshDetails;
@@ -14,14 +19,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Optional;
-import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
 @ExtendWith(MockitoExtension.class)
 class ListServiceCancelRefreshTest {
+
   @InjectMocks
   private ListService listService;
 
@@ -39,7 +39,8 @@ class ListServiceCancelRefreshTest {
     UUID userId = UUID.randomUUID();
     ListEntity list = TestDataFixture.getListEntityWithInProgressRefresh();
     ListRefreshDetails refreshDetails = list.getInProgressRefresh();
-    when(listRepository.findById(list.getId())).thenReturn(Optional.of(list));
+    when(listRepository.findByIdAndIsDeletedFalse(list.getId()))
+      .thenReturn(Optional.of(list));
     when(executionContext.getUserId()).thenReturn(userId);
     doNothing().when(listValidationService).validateCancelRefresh(list);
     listService.cancelRefresh(list.getId());

--- a/src/test/java/org/folio/list/service/ListServiceDeleteListTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceDeleteListTest.java
@@ -10,6 +10,7 @@ import org.folio.list.services.ListValidationService;
 import org.folio.list.utils.TestDataFixture;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -18,6 +19,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
@@ -40,10 +43,16 @@ class ListServiceDeleteListTest {
   void shouldDeleteList() {
     ListEntity entity = TestDataFixture.getListEntityWithSuccessRefresh();
     when(listRepository.findByIdAndIsDeletedFalse(entity.getId())).thenReturn(Optional.of(entity));
+    
     listValidationService.validateDelete(entity);
     listService.deleteList(entity.getId());
-    verify(listRepository, times(1)).deleteById(entity.getId());
+
     verify(listContentsRepository, times(1)).deleteContents(entity.getId());
+
+    // soft delete saves the entity with is_deleted=true
+    ArgumentCaptor<ListEntity> captor = ArgumentCaptor.forClass(ListEntity.class);
+    verify(listRepository, times(1)).save(captor.capture());
+    assertThat(captor.getValue().getIsDeleted()).isTrue();
   }
 
   @Test

--- a/src/test/java/org/folio/list/service/ListServiceDeleteListTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceDeleteListTest.java
@@ -39,7 +39,7 @@ class ListServiceDeleteListTest {
   @Test
   void shouldDeleteList() {
     ListEntity entity = TestDataFixture.getListEntityWithSuccessRefresh();
-    when(listRepository.findById(entity.getId())).thenReturn(Optional.of(entity));
+    when(listRepository.findByIdAndIsDeletedFalse(entity.getId())).thenReturn(Optional.of(entity));
     listValidationService.validateDelete(entity);
     listService.deleteList(entity.getId());
     verify(listRepository, times(1)).deleteById(entity.getId());
@@ -49,7 +49,7 @@ class ListServiceDeleteListTest {
   @Test
   void shouldNotDeleteIfValidationFailed() {
     ListEntity entity = TestDataFixture.getPrivateListEntity();
-    when(listRepository.findById(entity.getId())).thenReturn(Optional.of(entity));
+    when(listRepository.findByIdAndIsDeletedFalse(entity.getId())).thenReturn(Optional.of(entity));
     doThrow(new PrivateListOfAnotherUserException(entity, ListActions.DELETE))
       .when(listValidationService).validateDelete(entity);
     UUID entityId = entity.getId();

--- a/src/test/java/org/folio/list/service/ListServiceGetListContentsTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceGetListContentsTest.java
@@ -84,7 +84,7 @@ class ListServiceGetListContentsTest {
     expectedEntity.getSuccessRefresh().setRecordsCount(2);
 
     when(executionContext.getTenantId()).thenReturn(tenantId);
-    when(listRepository.findById(listId)).thenReturn(Optional.of(expectedEntity));
+    when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(expectedEntity));
     when(listContentsRepository.getContents(listId, successRefresh.getId(), new OffsetRequest(offset, size))).thenReturn(listContents);
     when(queryClient.getContents(contentsRequest)).thenReturn(expectedList);
     Optional<ResultsetPage> actualContent = listService.getListContents(listId, offset, size);
@@ -126,7 +126,7 @@ class ListServiceGetListContentsTest {
     expectedEntity.getSuccessRefresh().setRecordsCount(2);
 
     when(executionContext.getTenantId()).thenReturn(tenantId);
-    when(listRepository.findById(listId)).thenReturn(Optional.of(expectedEntity));
+    when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(expectedEntity));
     when(listContentsRepository.getContents(listId, successRefresh.getId(), new OffsetRequest(offset, size))).thenReturn(listContents);
     when(queryClient.getContents(contentsRequest)).thenReturn(expectedList);
     Optional<ResultsetPage> actualContent = listService.getListContents(listId, offset, size);
@@ -168,7 +168,7 @@ class ListServiceGetListContentsTest {
     expectedEntity.getSuccessRefresh().setRecordsCount(2);
 
     when(executionContext.getTenantId()).thenReturn(tenantId);
-    when(listRepository.findById(listId)).thenReturn(Optional.of(expectedEntity));
+    when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(expectedEntity));
     when(listContentsRepository.getContents(listId, successRefresh.getId(), new OffsetRequest(offset, size))).thenReturn(listContents);
     when(queryClient.getContents(contentsRequest)).thenReturn(expectedList);
     Optional<ResultsetPage> actualContent = listService.getListContents(listId, offset, size);
@@ -209,7 +209,7 @@ class ListServiceGetListContentsTest {
     expectedEntity.getSuccessRefresh().setRecordsCount(2);
 
     when(executionContext.getTenantId()).thenReturn(tenantId);
-    when(listRepository.findById(listId)).thenReturn(Optional.of(expectedEntity));
+    when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(expectedEntity));
     when(listContentsRepository.getContents(listId, successRefresh.getId(), new OffsetRequest(offset, size))).thenReturn(listContents);
     when(queryClient.getContents(contentsRequest)).thenReturn(expectedList);
     Optional<ResultsetPage> actualContent = listService.getListContents(listId, offset, size);
@@ -221,7 +221,7 @@ class ListServiceGetListContentsTest {
     UUID listId = UUID.randomUUID();
     Optional<ResultsetPage> emptyContent = Optional.of(new ResultsetPage().content(List.of()).totalRecords(0));
     ListEntity neverRefreshedList = TestDataFixture.getNeverRefreshedListEntity();
-    when(listRepository.findById(listId)).thenReturn(Optional.of(neverRefreshedList));
+    when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(neverRefreshedList));
     Optional<ResultsetPage> actualContent = listService.getListContents(listId, 0, 100);
     assertThat(actualContent).isEqualTo(emptyContent);
   }
@@ -230,7 +230,7 @@ class ListServiceGetListContentsTest {
   void shouldThrowExceptionWhenValidationFailed() {
     UUID listId = UUID.randomUUID();
     ListEntity listEntity = TestDataFixture.getNeverRefreshedListEntity();
-    when(listRepository.findById(listId)).thenReturn(Optional.of(listEntity));
+    when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(listEntity));
     doThrow(new PrivateListOfAnotherUserException(listEntity, ListActions.READ))
       .when(listValidationService).assertSharedOrOwnedByUser(listEntity, ListActions.READ);
     Assertions.assertThrows(PrivateListOfAnotherUserException.class, () -> listService.getListContents(listId, 0, 100));

--- a/src/test/java/org/folio/list/service/ListServiceGetListIdTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceGetListIdTest.java
@@ -45,7 +45,7 @@ class ListServiceGetListIdTest {
     ListEntity entity = TestDataFixture.getListEntityWithSuccessRefresh(UUID.randomUUID());
     ListDTO listDto = TestDataFixture.getListDTOSuccessRefresh(listId);
 
-    when(listRepository.findById(listId)).thenReturn(Optional.of(entity));
+    when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(entity));
     when(listMapper.toListDTO(entity)).thenReturn(listDto);
     var actual = listService.getListById(listId);
     assertThat(actual).contains(listDto);
@@ -55,7 +55,7 @@ class ListServiceGetListIdTest {
   void shouldThrowExceptionWhenValidationFailed() {
     UUID listId = UUID.randomUUID();
     ListEntity listEntity = TestDataFixture.getNeverRefreshedListEntity();
-    when(listRepository.findById(listId)).thenReturn(Optional.of(listEntity));
+    when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(listEntity));
     doThrow(new PrivateListOfAnotherUserException(listEntity, ListActions.READ))
       .when(listValidationService).assertSharedOrOwnedByUser(listEntity, ListActions.READ);
     Assertions.assertThrows(PrivateListOfAnotherUserException.class, () -> listService.getListById(listId));

--- a/src/test/java/org/folio/list/service/ListServicePostRefreshTest.java
+++ b/src/test/java/org/folio/list/service/ListServicePostRefreshTest.java
@@ -73,7 +73,7 @@ class ListServicePostRefreshTest {
 
     savedEntity.setInProgressRefresh(inProgressRefreshEntity);
 
-    when(listRepository.findById(savedEntity.getId())).thenReturn(Optional.of(fetchedEntity));
+    when(listRepository.findByIdAndIsDeletedFalse(savedEntity.getId())).thenReturn(Optional.of(fetchedEntity));
     when(listRepository.save(fetchedEntity)).thenReturn(savedEntity);
     when(refreshMapper.toListRefreshDTO(inProgressRefreshEntity)).thenReturn(inProgressRefreshDTO);
     when(executionContext.getUserId()).thenReturn(userId);
@@ -94,7 +94,7 @@ class ListServicePostRefreshTest {
     ListEntity fetchedEntity = TestDataFixture.getListEntityWithSuccessRefresh();
 
     ArgumentCaptor<ListEntity> listEntityCaptor = ArgumentCaptor.forClass(ListEntity.class);
-    when(listRepository.findById(listId)).thenReturn(Optional.of(fetchedEntity));
+    when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(fetchedEntity));
     when(listRepository.save(listEntityCaptor.capture())).thenReturn(fetchedEntity);
     when(refreshMapper.toListRefreshDTO(any(ListRefreshDetails.class))).thenReturn(mock(org.folio.list.domain.dto.ListRefreshDTO.class));
     when(executionContext.getUserId()).thenReturn(userId);
@@ -115,7 +115,7 @@ class ListServicePostRefreshTest {
     ListEntity fetchedEntity = TestDataFixture.getListEntityWithSuccessRefresh();
 
     ArgumentCaptor<ListEntity> listEntityCaptor = ArgumentCaptor.forClass(ListEntity.class);
-    when(listRepository.findById(listId)).thenReturn(Optional.of(fetchedEntity));
+    when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(fetchedEntity));
     when(listRepository.save(listEntityCaptor.capture())).thenReturn(fetchedEntity);
     when(refreshMapper.toListRefreshDTO(any(ListRefreshDetails.class))).thenReturn(mock(org.folio.list.domain.dto.ListRefreshDTO.class));
     when(executionContext.getUserId()).thenReturn(userId);
@@ -133,10 +133,9 @@ class ListServicePostRefreshTest {
   void shouldThrowExceptionWhenValidationFailed() {
     UUID listId = UUID.randomUUID();
     ListEntity listEntity = TestDataFixture.getNeverRefreshedListEntity();
-    when(listRepository.findById(listId)).thenReturn(Optional.of(listEntity));
+    when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(listEntity));
     doThrow(new PrivateListOfAnotherUserException(listEntity, ListActions.REFRESH))
       .when(listValidationService).validateRefresh(listEntity);
     Assertions.assertThrows(PrivateListOfAnotherUserException.class, () -> listService.performRefresh(listId));
   }
 }
-

--- a/src/test/java/org/folio/list/service/export/ListExportServiceTest.java
+++ b/src/test/java/org/folio/list/service/export/ListExportServiceTest.java
@@ -76,7 +76,7 @@ class ListExportServiceTest {
     ListEntity fetchedEntity = TestDataFixture.getListExportDetails().getList();
     ExportDetails exportDetails = TestDataFixture.getListExportDetails();
     ArgumentCaptor<ExportDetails> exportDetailsArgumentCaptor = ArgumentCaptor.forClass(ExportDetails.class);
-    when(listRepository.findById(listId)).thenReturn(Optional.of(fetchedEntity));
+    when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(fetchedEntity));
     when(listExportRepository.save(exportDetailsArgumentCaptor.capture())).thenReturn(exportDetails);
 
     when(listExportMapper.toListExportDTO(any(ExportDetails.class)))
@@ -112,7 +112,7 @@ class ListExportServiceTest {
     ListEntity fetchedEntity = TestDataFixture.getListExportDetails().getList();
     ExportDetails exportDetails = TestDataFixture.getListExportDetails();
     ArgumentCaptor<ExportDetails> exportDetailsArgumentCaptor = ArgumentCaptor.forClass(ExportDetails.class);
-    when(listRepository.findById(listId)).thenReturn(Optional.of(fetchedEntity));
+    when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(fetchedEntity));
     when(listExportRepository.save(exportDetailsArgumentCaptor.capture())).thenReturn(exportDetails);
 
     when(listExportMapper.toListExportDTO(any(ExportDetails.class)))
@@ -239,7 +239,7 @@ class ListExportServiceTest {
     ExportDetails exportDetails = TestDataFixture.getListExportDetails();
     ListEntity fetchedEntity = exportDetails.getList();
     UUID listId = fetchedEntity.getId();
-    when(listRepository.findById(listId)).thenReturn(Optional.of(fetchedEntity));
+    when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(fetchedEntity));
     when(listExportRepository.save(any(ExportDetails.class))).thenReturn(exportDetails);
     when(listExportMapper.toListExportDTO(exportDetails)).thenReturn(mock(ListExportDTO.class));
     when(listExportWorkerService.doAsyncExport(exportDetails)).thenReturn(CompletableFuture.completedFuture(null));

--- a/src/test/java/org/folio/list/service/refresh/RefreshFailedCallbackTest.java
+++ b/src/test/java/org/folio/list/service/refresh/RefreshFailedCallbackTest.java
@@ -32,7 +32,7 @@ class RefreshFailedCallbackTest {
     ListEntity entity = TestDataFixture.getListEntityWithInProgressRefresh();
     Throwable failureReason = new RuntimeException("Something Went Wrong");
     String expectedErrorCode = "unexpected.error";
-    when(listRepository.findById(entity.getId())).thenReturn(Optional.of(entity));
+    when(listRepository.findByIdAndIsDeletedFalse(entity.getId())).thenReturn(Optional.of(entity));
 
     failedRefreshService.accept(entity, new TaskTimer(), failureReason);
     assertThat(entity.getFailedRefresh().getErrorMessage()).isEqualTo(failureReason.getMessage());

--- a/src/test/java/org/folio/list/service/refresh/RefreshSuccessCallbackTest.java
+++ b/src/test/java/org/folio/list/service/refresh/RefreshSuccessCallbackTest.java
@@ -39,7 +39,7 @@ class RefreshSuccessCallbackTest {
   void shouldCompleteRefreshForNeverRefreshedList() {
     int recordsCount = 10;
     ListEntity entity = TestDataFixture.getListEntityWithInProgressRefresh();
-    when(listRepository.findById(entity.getId())).thenReturn(Optional.of(entity));
+    when(listRepository.findByIdAndIsDeletedFalse(entity.getId())).thenReturn(Optional.of(entity));
 
     successRefreshService.accept(entity, recordsCount, new TaskTimer());
     assertEquals(entity.getSuccessRefresh().getRecordsCount(), recordsCount);
@@ -53,7 +53,7 @@ class RefreshSuccessCallbackTest {
     int recordsCount = 10;
     ListEntity entity = TestDataFixture.getListEntityWithInProgressAndSuccessRefresh();
     UUID originalRefreshId = entity.getSuccessRefresh().getId();
-    when(listRepository.findById(entity.getId())).thenReturn(Optional.of(entity));
+    when(listRepository.findByIdAndIsDeletedFalse(entity.getId())).thenReturn(Optional.of(entity));
 
     successRefreshService.accept(entity, recordsCount, new TaskTimer());
     assertEquals(entity.getSuccessRefresh().getRecordsCount(), recordsCount);


### PR DESCRIPTION
# [Jira MODLISTS-71](https://issues.folio.org/browse/MODLISTS-71)

## Purpose
Lists should be able to be soft deleted and later accessible via the main `/lists` endpoint with special query parameter `includeDeleted`.

Deleted lists should no longer be accessible via `/lists/{id}/*`.

## Out of scope
- Returning special error responses when operations are attempted on deleted lists; currently, we just return 404 as though the list never existed/was hard deleted.
- Hard deleting or un-deleting a list
