### PR TITLE
MODFQMMGR-119: Add empty FQL operator handler to UserFriendlyQueryService

### DIFF
--- a/src/main/java/org/folio/list/services/UserFriendlyQueryService.java
+++ b/src/main/java/org/folio/list/services/UserFriendlyQueryService.java
@@ -21,18 +21,19 @@ public class UserFriendlyQueryService {
 
   private final QueryClient queryClient;
 
-  private final Map<Class<? extends FqlCondition<?>>, BiFunction<FqlCondition<?>, EntityType, String>> userFriendlyQuery = Map.of(
-    EqualsCondition.class, (cnd, ent) -> handleEquals((EqualsCondition) cnd, ent),
-    NotEqualsCondition.class, (cnd, ent) -> handleNotEquals((NotEqualsCondition) cnd, ent),
-    InCondition.class, (cnd, ent) -> handleIn((InCondition) cnd, ent),
-    NotInCondition.class, (cnd, ent) -> handleNotIn((NotInCondition) cnd, ent),
-    GreaterThanCondition.class, (cnd, ent) -> handleGreaterThan((GreaterThanCondition) cnd),
-    LessThanCondition.class, (cnd, ent) -> handleLessThan((LessThanCondition) cnd),
-    AndCondition.class, (cnd, ent) -> handleAnd((AndCondition) cnd, ent),
-    RegexCondition.class, (cnd, ent) -> handleRegEx((RegexCondition) cnd),
-    ContainsCondition.class, (cnd, ent) -> handleContains((ContainsCondition) cnd, ent),
-    NotContainsCondition.class, (cnd, ent) -> handleNotContains((NotContainsCondition) cnd, ent)
-    );
+  private final Map<Class<? extends FqlCondition<?>>, BiFunction<FqlCondition<?>, EntityType, String>> userFriendlyQuery = Map.ofEntries(
+    Map.entry(EqualsCondition.class, (cnd, ent) -> handleEquals((EqualsCondition) cnd, ent)),
+    Map.entry(NotEqualsCondition.class, (cnd, ent) -> handleNotEquals((NotEqualsCondition) cnd, ent)),
+    Map.entry(InCondition.class, (cnd, ent) -> handleIn((InCondition) cnd, ent)),
+    Map.entry(NotInCondition.class, (cnd, ent) -> handleNotIn((NotInCondition) cnd, ent)),
+    Map.entry(GreaterThanCondition.class, (cnd, ent) -> handleGreaterThan((GreaterThanCondition) cnd)),
+    Map.entry(LessThanCondition.class, (cnd, ent) -> handleLessThan((LessThanCondition) cnd)),
+    Map.entry(AndCondition.class, (cnd, ent) -> handleAnd((AndCondition) cnd, ent)),
+    Map.entry(RegexCondition.class, (cnd, ent) -> handleRegEx((RegexCondition) cnd)),
+    Map.entry(ContainsCondition.class, (cnd, ent) -> handleContains((ContainsCondition) cnd, ent)),
+    Map.entry(NotContainsCondition.class, (cnd, ent) -> handleNotContains((NotContainsCondition) cnd, ent)),
+    Map.entry(EmptyCondition.class, (cnd, ent) -> handleEmpty((EmptyCondition) cnd))
+  );
 
   public String getUserFriendlyQuery(FqlCondition<?> fqlCondition, EntityType entityType) {
     log.info("Computing user friendly query for fqlCondition: {}, entityType: {}", fqlCondition, entityType.getId());
@@ -98,6 +99,14 @@ public class UserFriendlyQueryService {
   private String handleNotContains(NotContainsCondition notContainsCondition, EntityType entityType) {
     BiFunction<EntityTypeColumn, Object, String> labelFn = (col, val) -> this.getLabel(UUID.fromString(val.toString()), col);
     return handleConditionWithPossibleIdValue(notContainsCondition, entityType, "does not contain", labelFn);
+  }
+
+  private String handleEmpty(EmptyCondition emptyCondition) {
+    if (Boolean.TRUE.equals(emptyCondition.value())) {
+      return emptyCondition.fieldName() + " is empty";
+    } else {
+      return emptyCondition.fieldName() + " is not empty";
+    }
   }
 
   private <T> String handleConditionWithPossibleIdValue(FieldCondition<T> condition,

--- a/src/test/java/org/folio/list/service/UserFriendlyQueryServiceTest.java
+++ b/src/test/java/org/folio/list/service/UserFriendlyQueryServiceTest.java
@@ -300,6 +300,24 @@ class UserFriendlyQueryServiceTest {
   }
 
   @Test
+  void shouldGetStringForFqlEmptyCondition() {
+    EntityType entityType = new EntityType();
+    EmptyCondition emptyCondition = new EmptyCondition("field1", true);
+    String expectedEmptyCondition = "field1 is empty";
+    String actualRegexCondition = userFriendlyQueryService.getUserFriendlyQuery(emptyCondition, entityType);
+    assertEquals(expectedEmptyCondition, actualRegexCondition);
+  }
+
+  @Test
+  void shouldGetStringForFqlNotEmptyCondition() {
+    EntityType entityType = new EntityType();
+    EmptyCondition notEmptyCondition = new EmptyCondition("field1", false);
+    String expectedNotEmptyCondition = "field1 is not empty";
+    String actualRegexCondition = userFriendlyQueryService.getUserFriendlyQuery(notEmptyCondition, entityType);
+    assertEquals(expectedNotEmptyCondition, actualRegexCondition);
+  }
+
+  @Test
   void shouldGetStringForFqlAndCondition() {
     EntityType entityType = new EntityType();
     RegexCondition regexCondition = new RegexCondition("field1", "^some value");


### PR DESCRIPTION
## Purpose
[MODFQMMGR-119](https://issues.folio.org/browse/MODFQMMGR-119): Create new operators to support searching for null/empty values 

This ticket adds a handler for the new $empty FQL operator to the UserFriendlyQueryService.

## Testing
- [x] All unit tests passed
- [x] UserFriendlyQueryService returns correct user friendly query for $empty operator  
