### PR TITLE
MODLISTS-83 Increase the list refresh query timeout and make it configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,23 +14,25 @@ The "mod-lists" module is responsible for handling lists within the system. It p
 mvn clean install
 ```
 ## Environment Variables
-| Name                                | Default Value            | Description                           |
-|-------------------------------------|--------------------------|---------------------------------------|
-| DB_HOST                             | localhost                | Postgres hostname                     |
-| DB_PORT                             | 5432                     | Postgres port                         |
-| DB_USERNAME                         | postgres                 | Postgres username                     |
-| DB_PASSWORD                         | postgres                 | Postgres password                     |
-| DB_DATABASE                         | postgres                 | Postgres database name                |
-| server.port                         | 8081                     | Server port                           |
-| MAX_LIST_SIZE                       | 1250000                  | max size of each list                 |
-| LIST_EXPORT_BATCH_SIZE              | 1000                     | batch size for exports                |
-| LIST_APP_S3_BUCKET                  | list-exports-us-west-2   | Name of the S3 bucket for exports     |
-| AWS_REGION                          | us-west-2                | region of the S3 bucket               |
-| AWS_URL                             | https://s3.amazonaws.com | end point for the S3 bucket           |
-| USE_AWS_SDK                         | false                    | Use the AWS SDK for S3 access         |                     |
-| S3_ACCESS_KEY_ID                    | -                        | access key for the S3 bucket          |
-| S3_SECRET_ACCESS_KEY                | -                        | secret key for the S3 bucket          |
-| spring.task.execution.pool.max-size | 10                       | refresh/export thread pool's max size |
+| Name                                            | Default Value            | Description                                                    |
+|-------------------------------------------------|--------------------------|----------------------------------------------------------------|
+| DB_HOST                                         | localhost                | Postgres hostname                                              |
+| DB_PORT                                         | 5432                     | Postgres port                                                  |
+| DB_USERNAME                                     | postgres                 | Postgres username                                              |
+| DB_PASSWORD                                     | postgres                 | Postgres password                                              |
+| DB_DATABASE                                     | postgres                 | Postgres database name                                         |
+| server.port                                     | 8081                     | Server port                                                    |
+| MAX_LIST_SIZE                                   | 1250000                  | max size of each list                                          |
+| LIST_EXPORT_BATCH_SIZE                          | 1000                     | batch size for exports                                         |
+| LIST_APP_S3_BUCKET                              | list-exports-us-west-2   | Name of the S3 bucket for exports                              |
+| AWS_REGION                                      | us-west-2                | region of the S3 bucket                                        |
+| AWS_URL                                         | https://s3.amazonaws.com | end point for the S3 bucket                                    |
+| USE_AWS_SDK                                     | false                    | Use the AWS SDK for S3 access                                  |                     |
+| S3_ACCESS_KEY_ID                                | -                        | access key for the S3 bucket                                   |
+| S3_SECRET_ACCESS_KEY                            | -                        | secret key for the S3 bucket                                   |
+| spring.task.execution.pool.max-size             | 10                       | refresh/export thread pool's max size                          |
+| mod-lists.general.refresh-query-timeout-minutes | 90                       | Max time to wait for an FQL query to run during a list refresh |
+
 
 > **Note:** `USE_AWS_SDK` is set to `false` when connected to minio.
 

--- a/src/main/java/org/folio/list/services/refresh/ListRefreshService.java
+++ b/src/main/java/org/folio/list/services/refresh/ListRefreshService.java
@@ -13,6 +13,7 @@ import org.folio.list.util.TaskTimer;
 import org.folio.querytool.domain.dto.QueryDetails;
 import org.folio.querytool.domain.dto.QueryIdentifier;
 import org.folio.querytool.domain.dto.SubmitQuery;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -29,7 +30,8 @@ import java.util.function.Supplier;
 public class ListRefreshService {
 
   private static final int GET_QUERY_TIME_DELAY_SECONDS = 10;
-  private static final int GET_QUERY_TIMEOUT_MINUTES = 30;
+  @Value("${mod-lists.general.refresh-query-timeout-minutes:90}")
+  private int getQueryTimeoutMinutes;
   private static final int DEFAULT_BATCH_SIZE = 1000;
 
   private final RefreshSuccessCallback refreshSuccessCallback;
@@ -82,7 +84,7 @@ public class ListRefreshService {
       () -> Awaitility.with()
         .pollInterval(GET_QUERY_TIME_DELAY_SECONDS, TimeUnit.SECONDS)
         .await()
-        .atMost(GET_QUERY_TIMEOUT_MINUTES, TimeUnit.MINUTES)
+        .atMost(getQueryTimeoutMinutes, TimeUnit.MINUTES)
         .until(() -> queryClient.getQuery(queryId).getStatus() != QueryDetails.StatusEnum.IN_PROGRESS));
     log.info("Query {} completed for list {}", queryId, list.getId());
     QueryDetails queryDetails = queryClient.getQuery(queryId);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 mod-lists:
   general:
     max-list-size: ${MAX_LIST_SIZE:1250000}
+    refresh-query-timeout-minutes: 90
   list-export:
     data-fetch-properties:
       batch-size: ${LIST_EXPORT_BATCH_SIZE:1000}

--- a/src/test/java/org/folio/list/service/ListRefreshServiceTest.java
+++ b/src/test/java/org/folio/list/service/ListRefreshServiceTest.java
@@ -15,6 +15,8 @@ import org.folio.querytool.domain.dto.QueryDetails;
 import org.folio.querytool.domain.dto.QueryIdentifier;
 import org.folio.querytool.domain.dto.SubmitQuery;
 import org.folio.spring.FolioExecutionContext;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -22,6 +24,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 import java.util.UUID;
@@ -53,6 +58,11 @@ class ListRefreshServiceTest {
   private ListRefreshService listRefreshService;
   @Mock
   private EntityManagerFlushService entityManagerFlushService;
+
+  @BeforeEach
+  void setup() {
+    ReflectionTestUtils.setField(listRefreshService, "getQueryTimeoutMinutes", 10);
+  }
 
   @Test
   void shouldStartRefresh() {

--- a/src/test/java/org/folio/list/service/ListServiceTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceTest.java
@@ -197,7 +197,7 @@ class ListServiceTest {
       .inProgressRefresh(actual.getInProgressRefresh())
       .failedRefresh(actual.getFailedRefresh())
       .version(actual.getVersion());
-    
+
     assertEquals(entity.getUserFriendlyQuery(), userFriendlyQuery);
     assertThat(actual).isEqualTo(expected);
   }


### PR DESCRIPTION
This increases the timeout for list refresh queries from 30 minutes to 90 minutes. It also makes it so this value can be configured at runtime via application properties or environment variables