### PR TITLE
[MODLISTS-86] Support nested properties in user friendly queries

### DIFF
--- a/src/main/java/org/folio/list/services/UserFriendlyQueryService.java
+++ b/src/main/java/org/folio/list/services/UserFriendlyQueryService.java
@@ -43,12 +43,12 @@ public class UserFriendlyQueryService {
 
   private String handleGreaterThan(GreaterThanCondition greaterThanCondition) {
     String operator = greaterThanCondition.orEqualTo() ? " >= " : " > ";
-    return greaterThanCondition.field().getColumnName() + operator + greaterThanCondition.value();
+    return greaterThanCondition.field().serialize() + operator + greaterThanCondition.value();
   }
 
   private String handleLessThan(LessThanCondition lessThanCondition) {
     String operator = lessThanCondition.orEqualTo() ? " <= " : " < ";
-    return lessThanCondition.field().getColumnName()  + operator + lessThanCondition.value();
+    return lessThanCondition.field().serialize()  + operator + lessThanCondition.value();
   }
 
   private String handleAnd(AndCondition andCondition, EntityType entityType) {
@@ -61,9 +61,9 @@ public class UserFriendlyQueryService {
 
   private String handleRegEx(RegexCondition regExCondition) {
     if (regExCondition.value().startsWith("^")) {
-      return regExCondition.field().getColumnName()  + " starts with " + regExCondition.value().substring(1);
+      return regExCondition.field().serialize()  + " starts with " + regExCondition.value().substring(1);
     }
-    return regExCondition.field().getColumnName()  + " contains " + regExCondition.value();
+    return regExCondition.field().serialize()  + " contains " + regExCondition.value();
   }
 
   private String handleEquals(EqualsCondition equalsCondition, EntityType entityType) {
@@ -104,9 +104,9 @@ public class UserFriendlyQueryService {
 
   private String handleEmpty(EmptyCondition emptyCondition) {
     if (Boolean.TRUE.equals(emptyCondition.value())) {
-      return emptyCondition.field().getColumnName()  + " is empty";
+      return emptyCondition.field().serialize()  + " is empty";
     } else {
-      return emptyCondition.field().getColumnName()  + " is not empty";
+      return emptyCondition.field().serialize()  + " is not empty";
     }
   }
 
@@ -135,11 +135,11 @@ public class UserFriendlyQueryService {
           // if we found this referencing column, use it as the basis for getting the label
           .map(column -> column.getName() + operatorWithPadding + labelFn.apply(column, condition.value()))
           // sensible fallback
-          .orElse(condition.field().getColumnName() + operatorWithPadding + condition.value());
+          .orElse(condition.field().serialize() + operatorWithPadding + condition.value());
       }
     } catch (Exception e) {
       log.error("Unexpected error when creating user friendly query for condition " + condition + ". Exception: " + e);
-      return condition.field().getColumnName() + operatorWithPadding + condition.value();
+      return condition.field().serialize() + operatorWithPadding + condition.value();
     }
   }
 
@@ -155,7 +155,6 @@ public class UserFriendlyQueryService {
     ContentsRequest contentsRequest = new ContentsRequest().entityTypeId(sourceEntityTypeId)
       .fields(List.of("id", field.getSource().getColumnName()))
       .ids(ids);
-    log.info("CR: {}", contentsRequest);
     return queryClient.getContents(contentsRequest)
       .stream()
       .map(map -> map.get(field.getSource().getColumnName()).toString())

--- a/src/test/java/org/folio/list/service/UserFriendlyQueryServiceTest.java
+++ b/src/test/java/org/folio/list/service/UserFriendlyQueryServiceTest.java
@@ -384,4 +384,13 @@ class UserFriendlyQueryServiceTest {
     String actualAndCondition = userFriendlyQueryService.getUserFriendlyQuery(andCondition, entityType);
     assertEquals(expectedAndCondition, actualAndCondition);
   }
+
+  @Test
+  void shouldProperlySerializeNestedProperties() {
+    EntityType entityType = new EntityType();
+    EmptyCondition condition = new EmptyCondition(new FqlField("field1[*]->foo->bar->baz"), false);
+    String expectedCondition = "field1[*]->foo->bar->baz is not empty";
+    String actualRegexCondition = userFriendlyQueryService.getUserFriendlyQuery(condition, entityType);
+    assertEquals(expectedCondition, actualRegexCondition);
+  }
 }


### PR DESCRIPTION
# [Jira MODLISTS-86](https://folio-org.atlassian.net/browse/MODLISTS-86)

## Purpose
This adds support for displaying nested properties in user friendly queries, e.g. `fund_distribution[*]->code`.

## Approach
This was added by replacing calls to `.getColumnName()` (which truncates any extra stuff from the root column) with `.serialize()`, which yields the entire (expected) field name.