### PR TITLE
Add support for contains_any and not_contains_any operators in UserFriendlyQueryService (MODFQMMGR-130)

### DIFF
--- a/src/main/java/org/folio/list/services/ListService.java
+++ b/src/main/java/org/folio/list/services/ListService.java
@@ -30,6 +30,7 @@ import org.folio.list.services.refresh.TimedStage;
 import org.folio.list.util.TaskTimer;
 import org.folio.querytool.domain.dto.ContentsRequest;
 import org.folio.querytool.domain.dto.EntityType;
+import org.folio.querytool.domain.dto.Field;
 import org.folio.querytool.domain.dto.ResultsetPage;
 import org.folio.list.domain.ListEntity;
 import org.folio.list.repository.ListRepository;
@@ -346,14 +347,11 @@ public class ListService {
     return appShutdownService.registerShutdownTask(executionContext, shutDownTask, taskName);
   }
 
-  // The below method retrieves all fields from the entity type. We are using it as a
-  // temporary workaround to supply fields in the list request. This maintains compatibility
-  // until the UI has been updated to pass the fields parameter in a list request.
   private List<String> getFieldsFromEntityType(EntityType entityType) {
-    List<String> fields = new ArrayList<>();
-    entityType
+    return entityType
       .getColumns()
-      .forEach(col -> fields.add(col.getName()));
-    return fields;
+      .stream()
+      .map(Field::getName)
+      .toList();
   }
 }

--- a/src/main/java/org/folio/list/services/UserFriendlyQueryService.java
+++ b/src/main/java/org/folio/list/services/UserFriendlyQueryService.java
@@ -33,6 +33,8 @@ public class UserFriendlyQueryService {
     Map.entry(RegexCondition.class, (cnd, ent) -> handleRegEx((RegexCondition) cnd)),
     Map.entry(ContainsAllCondition.class, (cnd, ent) -> handleContainsAll((ContainsAllCondition) cnd, ent)),
     Map.entry(NotContainsAllCondition.class, (cnd, ent) -> handleNotContainsAll((NotContainsAllCondition) cnd, ent)),
+    Map.entry(ContainsAnyCondition.class, (cnd, ent) -> handleContainsAny((ContainsAnyCondition) cnd, ent)),
+    Map.entry(NotContainsAnyCondition.class, (cnd, ent) -> handleNotContainsAny((NotContainsAnyCondition) cnd, ent)),
     Map.entry(EmptyCondition.class, (cnd, ent) -> handleEmpty((EmptyCondition) cnd))
   );
 
@@ -106,6 +108,22 @@ public class UserFriendlyQueryService {
       return getLabel(ids, col, true);
     };
     return handleConditionWithPossibleIdValue(notContainsAllCondition, entityType, "does not contain all", labelFn);
+  }
+
+  private String handleContainsAny(ContainsAnyCondition containsAnyCondition, EntityType entityType) {
+    BiFunction<Field, List<Object>, String> labelFn = (col, val) -> {
+      List<List<String>> ids = val.stream().map(uuidStr -> List.of(uuidStr.toString())).toList();
+      return getLabel(ids, col, true);
+    };
+    return handleConditionWithPossibleIdValue(containsAnyCondition, entityType, "contains any", labelFn);
+  }
+
+  private String handleNotContainsAny(NotContainsAnyCondition notContainsAnyCondition, EntityType entityType) {
+    BiFunction<Field, List<Object>, String> labelFn = (col, val) -> {
+      List<List<String>> ids = val.stream().map(uuidStr -> List.of(uuidStr.toString())).toList();
+      return getLabel(ids, col, true);
+    };
+    return handleConditionWithPossibleIdValue(notContainsAnyCondition, entityType, "does not contain any", labelFn);
   }
 
   private String handleEmpty(EmptyCondition emptyCondition) {

--- a/src/test/java/org/folio/list/service/UserFriendlyQueryServiceTest.java
+++ b/src/test/java/org/folio/list/service/UserFriendlyQueryServiceTest.java
@@ -1,6 +1,18 @@
 package org.folio.list.service;
 
-import org.folio.fql.model.*;
+import org.folio.fql.model.AndCondition;
+import org.folio.fql.model.ContainsAllCondition;
+import org.folio.fql.model.ContainsAnyCondition;
+import org.folio.fql.model.EmptyCondition;
+import org.folio.fql.model.EqualsCondition;
+import org.folio.fql.model.GreaterThanCondition;
+import org.folio.fql.model.InCondition;
+import org.folio.fql.model.LessThanCondition;
+import org.folio.fql.model.NotContainsAllCondition;
+import org.folio.fql.model.NotContainsAnyCondition;
+import org.folio.fql.model.NotEqualsCondition;
+import org.folio.fql.model.NotInCondition;
+import org.folio.fql.model.RegexCondition;
 import org.folio.fql.model.field.FqlField;
 import org.folio.list.rest.QueryClient;
 import org.folio.list.services.UserFriendlyQueryService;
@@ -228,10 +240,10 @@ class UserFriendlyQueryServiceTest {
   @Test
   void shouldGetStringForFqlContainsAllConditionWithoutIdColumn() {
     EntityType entityType = new EntityType();
-    ContainsAllCondition containsCondition = new ContainsAllCondition(new FqlField("field1"), List.of("value1"));
-    String expectedContainsCondition = "field1 contains all [value1]";
-    String actualContainsCondition = userFriendlyQueryService.getUserFriendlyQuery(containsCondition, entityType);
-    assertEquals(expectedContainsCondition, actualContainsCondition);
+    ContainsAllCondition containsAllCondition = new ContainsAllCondition(new FqlField("field1"), List.of("value1"));
+    String expectedContainsAllCondition = "field1 contains all [value1]";
+    String actualContainsAllCondition = userFriendlyQueryService.getUserFriendlyQuery(containsAllCondition, entityType);
+    assertEquals(expectedContainsAllCondition, actualContainsAllCondition);
   }
 
   @Test
@@ -260,18 +272,60 @@ class UserFriendlyQueryServiceTest {
 
     when(queryClient.getContents(contentsRequest)).thenReturn(entityContents);
 
-    String expectedNotInCondition = "field2 contains all [value1, value2]";
-    String actualNotInCondition = userFriendlyQueryService.getUserFriendlyQuery(containsAllCondition, entityType);
-    assertEquals(expectedNotInCondition, actualNotInCondition);
+    String expectedContainsAllCondition = "field2 contains all [value1, value2]";
+    String actualContainsAllCondition = userFriendlyQueryService.getUserFriendlyQuery(containsAllCondition, entityType);
+    assertEquals(expectedContainsAllCondition, actualContainsAllCondition);
   }
+
+  @Test
+  void shouldGetStringForFqlContainsAnyConditionWithoutIdColumn() {
+    EntityType entityType = new EntityType();
+    ContainsAnyCondition containsAnyCondition = new ContainsAnyCondition(new FqlField("field1"), List.of("value1"));
+    String expectedContainsAnyCondition = "field1 contains any [value1]";
+    String actualContainsAnyCondition = userFriendlyQueryService.getUserFriendlyQuery(containsAnyCondition, entityType);
+    assertEquals(expectedContainsAnyCondition, actualContainsAnyCondition);
+  }
+
+  @Test
+  void shouldGetStringForFqlContainsAnyConditionWithIdColumn() {
+    List<Map<String, Object>> entityContents = List.of(
+      Map.of("field1", "value1"),
+      Map.of("field1", "value2")
+    );
+    UUID entityTypeId = UUID.randomUUID();
+    UUID sourceEntityTypeId = UUID.randomUUID();
+    UUID value1 = UUID.randomUUID();
+    UUID value2 = UUID.randomUUID();
+    List<List<String>> ids = List.of(
+      List.of(value1.toString()),
+      List.of(value2.toString())
+    );
+    List<String> fields = List.of("id", "field1");
+    ContentsRequest contentsRequest = new ContentsRequest().entityTypeId(sourceEntityTypeId)
+      .fields(fields)
+      .ids(ids);
+    SourceColumn sourceColumn = new SourceColumn().entityTypeId(sourceEntityTypeId.toString()).columnName("field1");
+    EntityTypeColumn column = new EntityTypeColumn().name("field1");
+    EntityTypeColumn column1 = new EntityTypeColumn().name("field2").idColumnName("field1").source(sourceColumn);
+    EntityType entityType = new EntityType().id(entityTypeId.toString()).columns(List.of(column, column1));
+    ContainsAnyCondition containsAnyCondition = new ContainsAnyCondition(new FqlField("field1"), List.of(value1, value2));
+
+    when(queryClient.getContents(contentsRequest)).thenReturn(entityContents);
+
+    String expectedContainsAnyCondition = "field2 contains any [value1, value2]";
+    String actualContainsAnyCondition = userFriendlyQueryService.getUserFriendlyQuery(containsAnyCondition, entityType);
+    assertEquals(expectedContainsAnyCondition, actualContainsAnyCondition);
+  }
+
+
 
   @Test
   void shouldGetStringForFqlNotContainsAllConditionWithoutIdColumn() {
     EntityType entityType = new EntityType();
-    NotContainsAllCondition notContainsCondition = new NotContainsAllCondition(new FqlField("field1"), List.of("value1"));
-    String expectedNotContainsCondition = "field1 does not contain all [value1]";
-    String actualNotContainsCondition = userFriendlyQueryService.getUserFriendlyQuery(notContainsCondition, entityType);
-    assertEquals(expectedNotContainsCondition, actualNotContainsCondition);
+    NotContainsAllCondition notContainsAllCondition = new NotContainsAllCondition(new FqlField("field1"), List.of("value1"));
+    String expectedNotContainsAllCondition = "field1 does not contain all [value1]";
+    String actualNotContainsAllCondition = userFriendlyQueryService.getUserFriendlyQuery(notContainsAllCondition, entityType);
+    assertEquals(expectedNotContainsAllCondition, actualNotContainsAllCondition);
   }
 
   @Test
@@ -300,9 +354,49 @@ class UserFriendlyQueryServiceTest {
 
     when(queryClient.getContents(contentsRequest)).thenReturn(entityContents);
 
-    String expectedNotInCondition = "field2 does not contain all [value1, value2]";
-    String actualNotInCondition = userFriendlyQueryService.getUserFriendlyQuery(notContainsAllCondition, entityType);
-    assertEquals(expectedNotInCondition, actualNotInCondition);
+    String expectedNotContainsAllCondition = "field2 does not contain all [value1, value2]";
+    String actualNotContainsAllCondition = userFriendlyQueryService.getUserFriendlyQuery(notContainsAllCondition, entityType);
+    assertEquals(expectedNotContainsAllCondition, actualNotContainsAllCondition);
+  }
+
+  @Test
+  void shouldGetStringForFqlNotContainsAnyConditionWithoutIdColumn() {
+    EntityType entityType = new EntityType();
+    NotContainsAnyCondition notContainsAnyCondition = new NotContainsAnyCondition(new FqlField("field1"), List.of("value1"));
+    String expectedNotContainsAnyCondition = "field1 does not contain any [value1]";
+    String actualNotContainsAnyCondition = userFriendlyQueryService.getUserFriendlyQuery(notContainsAnyCondition, entityType);
+    assertEquals(expectedNotContainsAnyCondition, actualNotContainsAnyCondition);
+  }
+
+  @Test
+  void shouldGetStringForFqlNotContainsAnyConditionWithIdColumn() {
+    List<Map<String, Object>> entityContents = List.of(
+      Map.of("field1", "value1"),
+      Map.of("field1", "value2")
+    );
+    UUID entityTypeId = UUID.randomUUID();
+    UUID sourceEntityTypeId = UUID.randomUUID();
+    UUID value1 = UUID.randomUUID();
+    UUID value2 = UUID.randomUUID();
+    List<List<String>> ids = List.of(
+      List.of(value1.toString()),
+      List.of(value2.toString())
+    );
+    List<String> fields = List.of("id", "field1");
+    ContentsRequest contentsRequest = new ContentsRequest().entityTypeId(sourceEntityTypeId)
+      .fields(fields)
+      .ids(ids);
+    SourceColumn sourceColumn = new SourceColumn().entityTypeId(sourceEntityTypeId.toString()).columnName("field1");
+    EntityTypeColumn column = new EntityTypeColumn().name("field1");
+    EntityTypeColumn column1 = new EntityTypeColumn().name("field2").idColumnName("field1").source(sourceColumn);
+    EntityType entityType = new EntityType().id(entityTypeId.toString()).columns(List.of(column, column1));
+    NotContainsAnyCondition notContainsAnyCondition = new NotContainsAnyCondition(new FqlField("field1"), List.of(value1, value2));
+
+    when(queryClient.getContents(contentsRequest)).thenReturn(entityContents);
+
+    String expectedNotContainsAnyCondition = "field2 does not contain any [value1, value2]";
+    String actualNotContainsAnyCondition = userFriendlyQueryService.getUserFriendlyQuery(notContainsAnyCondition, entityType);
+    assertEquals(expectedNotContainsAnyCondition, actualNotContainsAnyCondition);
   }
 
   @Test


### PR DESCRIPTION
## Purpose
Add handling for contains_any and not_contains_any operators in UserFriendlyQueryService to support 

[MODFQMMGR-130](https://folio-org.atlassian.net/browse/MODFQMMGR-130): Add contains_any and not_contains_any operators