### PR TITLE
MODLISTS-88 Bump the Spring Boot dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.3</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>org.folio</groupId>
@@ -23,7 +23,7 @@
 
   <properties>
     <!-- runtime dependencies -->
-    <folio-spring-base.version>7.3.0-SNAPSHOT</folio-spring-base.version>
+    <folio-spring-base.version>8.1.0</folio-spring-base.version>
     <commons-collections4.version>4.4</commons-collections4.version>
     <folio-service-tools.version>3.1.0</folio-service-tools.version>
     <mapstruct.version>1.5.2.Final</mapstruct.version>


### PR DESCRIPTION
This commit bumps our Spring Boot dependency from 3.2.0 to 3.2.3 (the lastest stable release). It also bumps our folio-spring-base version from 7.3.0-SNAPSHOT to 8.1.0, to keep our Spring-based transitive dependencies in line with the updated Spring Boot version