### PR TITLE
Pass fields in GET /lists/contents request. Retrieve all fields if "fields" parameter is not provided

### DIFF
--- a/src/main/java/org/folio/list/controller/ListController.java
+++ b/src/main/java/org/folio/list/controller/ListController.java
@@ -85,8 +85,8 @@ public class ListController implements ListApi {
   }
 
   @Override
-  public ResponseEntity<ResultsetPage> getListContents(UUID id, Integer offset, Integer size) {
-    return listService.getListContents(id, offset, size)
+  public ResponseEntity<ResultsetPage> getListContents(UUID id, List<String> fields, Integer offset, Integer size) {
+    return listService.getListContents(id, fields, offset, size)
       .map(ResponseEntity::ok)
       .orElseThrow(() -> new ListNotFoundException(id, ListActions.READ));
   }

--- a/src/main/resources/swagger.api/list.yaml
+++ b/src/main/resources/swagger.api/list.yaml
@@ -219,6 +219,15 @@ paths:
       description: gets the list contents (if exists).
       parameters:
         - $ref: '#/components/parameters/id'
+        - name: fields
+          in: query
+          description: List of fields to retrieve content for
+          required: false
+          schema:
+            type: array
+            items:
+              type:
+                string
         - name: offset
           in: query
           description: Offset to start retrieving items from

--- a/src/test/java/org/folio/list/controller/ListControllerListContentsTest.java
+++ b/src/test/java/org/folio/list/controller/ListControllerListContentsTest.java
@@ -37,14 +37,15 @@ class ListControllerListContentsTest {
     UUID listId = UUID.randomUUID();
     Integer offset = 0;
     Integer size = 2;
-    var requestBuilder = get("/lists/" + listId + "/contents?size=2&offset=0")
+    List<String> fields = List.of("key1", "key2", "key3", "key4");
+    var requestBuilder = get("/lists/" + listId + "/contents?size=2&offset=0&fields=key1,key2,key3,key4")
       .contentType(APPLICATION_JSON)
       .header(XOkapiHeaders.TENANT, listId);
     List<Map<String, Object>> expectedList = List.of(
       Map.of("key1", "value1", "key2", "value2"),
       Map.of("key3", "value3", "key4", "value4"));
     Optional<ResultsetPage> expectedContent = Optional.of(new ResultsetPage().content(expectedList).totalRecords(expectedList.size()));
-    when(listService.getListContents(listId, offset, size)).thenReturn(expectedContent);
+    when(listService.getListContents(listId, fields, offset, size)).thenReturn(expectedContent);
     mockMvc.perform(requestBuilder)
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.content[0]", is(expectedList.get(0))))
@@ -56,11 +57,12 @@ class ListControllerListContentsTest {
     UUID listId = UUID.randomUUID();
     Integer offset = 0;
     Integer size = 0;
-    var requestBuilder = get("/lists/" + listId + "/contents?size=0&offset=0")
+    List<String> fields = List.of("key1");
+    var requestBuilder = get("/lists/" + listId + "/contents?size=0&offset=0&fields=key1")
       .contentType(APPLICATION_JSON)
       .header(XOkapiHeaders.TENANT, listId);
     Optional<ResultsetPage> expectedContent = Optional.empty();
-    when(listService.getListContents(listId, offset, size)).thenReturn(expectedContent);
+    when(listService.getListContents(listId, fields, offset, size)).thenReturn(expectedContent);
     mockMvc.perform(requestBuilder)
       .andExpect(status().isNotFound())
       .andExpect(jsonPath("$.code", is("read-list.not.found")));
@@ -73,12 +75,13 @@ class ListControllerListContentsTest {
     listEntity.setId(listId);
     Integer offset = 0;
     Integer size = 0;
+    List<String> fields = List.of("key1");
 
-    var requestBuilder = get("/lists/" + listId + "/contents?size=0&offset=0")
+    var requestBuilder = get("/lists/" + listId + "/contents?size=0&offset=0&fields=key1")
       .contentType(APPLICATION_JSON)
       .header(XOkapiHeaders.TENANT, listId);
 
-    when(listService.getListContents(listId, offset, size))
+    when(listService.getListContents(listId, fields, offset, size))
       .thenThrow(new PrivateListOfAnotherUserException(listEntity, ListActions.READ));
 
     mockMvc.perform(requestBuilder)

--- a/src/test/java/org/folio/list/service/ListServiceGetListContentsTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceGetListContentsTest.java
@@ -7,16 +7,20 @@ import org.folio.list.domain.ListRefreshDetails;
 import org.folio.list.exception.PrivateListOfAnotherUserException;
 import org.folio.list.repository.ListContentsRepository;
 import org.folio.list.repository.ListRepository;
+import org.folio.list.rest.EntityTypeClient;
 import org.folio.list.rest.QueryClient;
 import org.folio.list.services.ListActions;
 import org.folio.list.services.ListService;
 import org.folio.list.services.ListValidationService;
 import org.folio.list.utils.TestDataFixture;
 import org.folio.querytool.domain.dto.ContentsRequest;
+import org.folio.querytool.domain.dto.EntityType;
+import org.folio.querytool.domain.dto.EntityTypeColumn;
 import org.folio.querytool.domain.dto.ResultsetPage;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.data.OffsetRequest;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -46,6 +50,8 @@ class ListServiceGetListContentsTest {
   private FqlService fqlService;
   @Mock
   private QueryClient queryClient;
+  @Mock
+  private EntityTypeClient entityTypeClient;
   @InjectMocks
   private ListService listService;
 
@@ -90,12 +96,12 @@ class ListServiceGetListContentsTest {
     when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(expectedEntity));
     when(listContentsRepository.getContents(listId, successRefresh.getId(), new OffsetRequest(offset, size))).thenReturn(listContents);
     when(queryClient.getContents(contentsRequest)).thenReturn(expectedList);
-    Optional<ResultsetPage> actualContent = listService.getListContents(listId, offset, size);
+    Optional<ResultsetPage> actualContent = listService.getListContents(listId, fields, offset, size);
     assertThat(actualContent).isEqualTo(expectedContent);
   }
 
   @Test
-  void shouldReturnRequestedFieldsPlusIdsIfIdsNotIncludedInFields() {
+  void shouldGetFieldsFromEntityTypeIfNotProvided() {
     String tenantId = "tenant_01";
     UUID entityTypeId = UUID.randomUUID();
     UUID listId = UUID.randomUUID();
@@ -103,51 +109,10 @@ class ListServiceGetListContentsTest {
       List.of(UUID.randomUUID().toString()),
       List.of(UUID.randomUUID().toString())
     );
-    int offset = 0;
-    int size = 2;
-    int contentVersion = 2;
-    List<String> fields = new ArrayList<>(List.of("key1", "key2"));
-    ContentsRequest contentsRequest = new ContentsRequest().entityTypeId(entityTypeId)
-      .fields(fields)
-      .ids(contentIds);
-    List<Map<String, Object>> expectedList = List.of(
-      Map.of("id", contentIds.get(0), "key1", "value1", "key2", "value2"),
-      Map.of("id", contentIds.get(1), "key1", "value3", "key2", "value4")
+    List<EntityTypeColumn> columns = List.of(
+      new EntityTypeColumn().name("id")
     );
-    Optional<ResultsetPage> expectedContent = Optional.of(new ResultsetPage().content(expectedList).totalRecords(expectedList.size()));
-
-    List<ListContent> listContents = contentIds.stream().map(id -> {
-      ListContent content = new ListContent();
-      content.setContentId(id);
-      return content;
-    }).toList();
-
-    ListEntity expectedEntity = new ListEntity();
-    ListRefreshDetails successRefresh = new ListRefreshDetails();
-    successRefresh.setContentVersion(contentVersion);
-    expectedEntity.setSuccessRefresh(successRefresh);
-    expectedEntity.setEntityTypeId(entityTypeId);
-    expectedEntity.setId(listId);
-    expectedEntity.setFields(fields);
-    expectedEntity.getSuccessRefresh().setRecordsCount(2);
-
-    when(executionContext.getTenantId()).thenReturn(tenantId);
-    when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(expectedEntity));
-    when(listContentsRepository.getContents(listId, successRefresh.getId(), new OffsetRequest(offset, size))).thenReturn(listContents);
-    when(queryClient.getContents(contentsRequest)).thenReturn(expectedList);
-    Optional<ResultsetPage> actualContent = listService.getListContents(listId, offset, size);
-    assertThat(actualContent).isEqualTo(expectedContent);
-  }
-
-  @Test
-  void shouldReturnContentPageWithIdsForEmptyFields() {
-    String tenantId = "tenant_01";
-    UUID entityTypeId = UUID.randomUUID();
-    UUID listId = UUID.randomUUID();
-    List<List<String>> contentIds = List.of(
-      List.of(UUID.randomUUID().toString()),
-      List.of(UUID.randomUUID().toString())
-    );
+    EntityType entityType = new EntityType().name("entity-type").columns(columns);
     int offset = 0;
     int size = 2;
     int contentVersion = 2;
@@ -177,64 +142,22 @@ class ListServiceGetListContentsTest {
     expectedEntity.getSuccessRefresh().setRecordsCount(2);
 
     when(executionContext.getTenantId()).thenReturn(tenantId);
+    when(entityTypeClient.getEntityType(entityTypeId)).thenReturn(entityType);
     when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(expectedEntity));
     when(listContentsRepository.getContents(listId, successRefresh.getId(), new OffsetRequest(offset, size))).thenReturn(listContents);
     when(queryClient.getContents(contentsRequest)).thenReturn(expectedList);
-    Optional<ResultsetPage> actualContent = listService.getListContents(listId, offset, size);
-    assertThat(actualContent).isEqualTo(expectedContent);
-  }
-
-  @Test
-  void shouldReturnContentPageWithIdsForNullFields() {
-    String tenantId = "tenant_01";
-    UUID entityTypeId = UUID.randomUUID();
-    UUID listId = UUID.randomUUID();
-    List<List<String>> contentIds = List.of(
-      List.of(UUID.randomUUID().toString()),
-      List.of(UUID.randomUUID().toString())
-    );
-    int offset = 0;
-    int size = 2;
-    int contentVersion = 2;
-    List<String> fields = List.of("id");
-    ContentsRequest contentsRequest = new ContentsRequest().entityTypeId(entityTypeId)
-      .fields(fields)
-      .ids(contentIds);
-    List<Map<String, Object>> expectedList = List.of(
-      Map.of("id", contentIds.get(0)),
-      Map.of("id", contentIds.get(1))
-    );
-    Optional<ResultsetPage> expectedContent = Optional.of(new ResultsetPage().content(expectedList).totalRecords(expectedList.size()));
-
-    List<ListContent> listContents = contentIds.stream().map(id -> {
-      ListContent content = new ListContent();
-      content.setContentId(id);
-      return content;
-    }).toList();
-
-    ListEntity expectedEntity = new ListEntity();
-    ListRefreshDetails successRefresh = new ListRefreshDetails();
-    successRefresh.setContentVersion(contentVersion);
-    expectedEntity.setSuccessRefresh(successRefresh);
-    expectedEntity.setEntityTypeId(entityTypeId);
-    expectedEntity.setId(listId);
-    expectedEntity.getSuccessRefresh().setRecordsCount(2);
-
-    when(executionContext.getTenantId()).thenReturn(tenantId);
-    when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(expectedEntity));
-    when(listContentsRepository.getContents(listId, successRefresh.getId(), new OffsetRequest(offset, size))).thenReturn(listContents);
-    when(queryClient.getContents(contentsRequest)).thenReturn(expectedList);
-    Optional<ResultsetPage> actualContent = listService.getListContents(listId, offset, size);
+    Optional<ResultsetPage> actualContent = listService.getListContents(listId, fields, offset, size);
     assertThat(actualContent).isEqualTo(expectedContent);
   }
 
   @Test
   void shouldReturnEmptyContentPageIfNotRefreshed() {
     UUID listId = UUID.randomUUID();
+    List<String> fields = List.of("id", "key1", "key2");
     Optional<ResultsetPage> emptyContent = Optional.of(new ResultsetPage().content(List.of()).totalRecords(0));
     ListEntity neverRefreshedList = TestDataFixture.getNeverRefreshedListEntity();
     when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(neverRefreshedList));
-    Optional<ResultsetPage> actualContent = listService.getListContents(listId, 0, 100);
+    Optional<ResultsetPage> actualContent = listService.getListContents(listId, fields, 0, 100);
     assertThat(actualContent).isEqualTo(emptyContent);
   }
 
@@ -242,9 +165,10 @@ class ListServiceGetListContentsTest {
   void shouldThrowExceptionWhenValidationFailed() {
     UUID listId = UUID.randomUUID();
     ListEntity listEntity = TestDataFixture.getNeverRefreshedListEntity();
+    List<String> fields = List.of("id", "key1", "key2");
     when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(listEntity));
     doThrow(new PrivateListOfAnotherUserException(listEntity, ListActions.READ))
       .when(listValidationService).assertSharedOrOwnedByUser(listEntity, ListActions.READ);
-    Assertions.assertThrows(PrivateListOfAnotherUserException.class, () -> listService.getListContents(listId, 0, 100));
+    Assertions.assertThrows(PrivateListOfAnotherUserException.class, () -> listService.getListContents(listId, fields, 0, 100));
   }
 }


### PR DESCRIPTION
## Purpose
Temporary change to retrieve contents for all fields in entity type definition. This will keep things working until the UI is updated to send desired fields in contents request. This PR also provides support for passing the list of fields to retrieve content for in the GET /lists/contents API, although the UI will need to be updated to support that change.

Fix for [MODLISTS-90](https://folio-org.atlassian.net/browse/MODLISTS-90): Newly selected columns aren't populated with data
