### PR TITLE
MODLISTS-91: Accept list of fields to export in export request body

### DIFF
--- a/src/main/java/org/folio/list/controller/ListExportController.java
+++ b/src/main/java/org/folio/list/controller/ListExportController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.UUID;
 
 @RequiredArgsConstructor
@@ -25,8 +26,8 @@ public class ListExportController implements ListExportApi {
   private final ListExportService listExportService;
 
   @Override
-  public ResponseEntity<ListExportDTO> exportList(UUID listId) {
-    var listExportDto = listExportService.createExport(listId);
+  public ResponseEntity<ListExportDTO> exportList(UUID listId, List<String> fields) {
+    var listExportDto = listExportService.createExport(listId, fields);
     return new ResponseEntity<>(listExportDto, HttpStatus.CREATED);
   }
 

--- a/src/main/java/org/folio/list/domain/ExportDetails.java
+++ b/src/main/java/org/folio/list/domain/ExportDetails.java
@@ -12,6 +12,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -34,6 +35,10 @@ public class ExportDetails {
   @ManyToOne
   @JoinColumn(name = "list_id")
   private ListEntity list;
+
+  @NotNull
+  @Column(name = "fields")
+  private List<String> fields;
 
   @Column(name = "status")
   @NotNull

--- a/src/main/java/org/folio/list/mapper/ListExportMapper.java
+++ b/src/main/java/org/folio/list/mapper/ListExportMapper.java
@@ -14,5 +14,6 @@ public interface ListExportMapper {
   @Mapping(target = "createdBy", source = "exportDetails.createdBy")
   @Mapping(target = "startDate", source = "exportDetails.startDate")
   @Mapping(target = "endDate", source = "exportDetails.endDate")
+  @Mapping(target = "fields", source = "exportDetails.fields")
   ListExportDTO toListExportDTO(ExportDetails exportDetails);
 }

--- a/src/main/java/org/folio/list/services/export/CsvCreator.java
+++ b/src/main/java/org/folio/list/services/export/CsvCreator.java
@@ -71,7 +71,7 @@ public class CsvCreator {
       }
       log.info("Export in progress for exportId {}. Fetched a batch of {} IDs.", exportDetails.getExportId(), ids.size());
       ContentsRequest contentsRequest = new ContentsRequest().entityTypeId(list.getEntityTypeId())
-        .fields(list.getFields())
+        .fields(exportDetails.getFields())
         .ids(ids);
       var sortedContents = queryClient.getContents(contentsRequest);
       csvWriter.writeCsv(sortedContents, localStorageOutputStream);

--- a/src/main/resources/db/changelog/changes/v1.1.0/changelog-v1.1.0.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/changelog-v1.1.0.xml
@@ -10,4 +10,9 @@
   <include file="sql/update-list-refresh-details-table.sql" relativeToChangelogFile="true"/>
   <include file="yml/add-list-details-is-deleted-column.yaml" relativeToChangelogFile="true"/>
   <include file="xml/update-list-contents-table.xml" relativeToChangelogFile="true"/>
+  <changeSet id="UILISTS-110" author="bsharp@ebsco.com">
+    <sql>
+      ALTER TABLE export_details ADD fields text[];
+    </sql>
+  </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/swagger.api/list.yaml
+++ b/src/main/resources/swagger.api/list.yaml
@@ -270,6 +270,15 @@ paths:
       description: Exports the list.
       parameters:
         - $ref: '#/components/parameters/id'
+      requestBody:
+        description: Export request
+        required: false
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: string
       responses:
         '201':
           description: 'returns if a list export request submitted successfully'

--- a/src/main/resources/swagger.api/schemas/ListExportDTO.json
+++ b/src/main/resources/swagger.api/schemas/ListExportDTO.json
@@ -37,6 +37,13 @@
       "description": "ID of the user who wants to export the list",
       "type": "string",
       "format": "UUID"
+    },
+    "fields": {
+      "description": "List of fields to export",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "additionalProperties": false,

--- a/src/test/java/org/folio/list/service/export/CsvCreatorTest.java
+++ b/src/test/java/org/folio/list/service/export/CsvCreatorTest.java
@@ -131,6 +131,7 @@ class CsvCreatorTest {
     exportDetails.setExportId(exportId);
     exportDetails.setList(entity);
     exportDetails.setStatus(AsyncProcessStatus.IN_PROGRESS);
+    exportDetails.setFields(entity.getFields());
     return exportDetails;
   }
 }

--- a/src/test/java/org/folio/list/service/export/ListExportServiceTest.java
+++ b/src/test/java/org/folio/list/service/export/ListExportServiceTest.java
@@ -29,6 +29,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -73,6 +74,7 @@ class ListExportServiceTest {
   void shouldSaveExport() {
     UUID listId = TestDataFixture.getListExportDetails().getList().getId();
     UUID userId = UUID.randomUUID();
+    List<String> fields = List.of("field1", "field2");
     ListEntity fetchedEntity = TestDataFixture.getListExportDetails().getList();
     ExportDetails exportDetails = TestDataFixture.getListExportDetails();
     ArgumentCaptor<ExportDetails> exportDetailsArgumentCaptor = ArgumentCaptor.forClass(ExportDetails.class);
@@ -85,7 +87,7 @@ class ListExportServiceTest {
     when(listExportWorkerService.doAsyncExport(exportDetails))
       .thenReturn(CompletableFuture.completedFuture(true));
 
-    listExportService.createExport(listId);
+    listExportService.createExport(listId, fields);
 
     // Two calls made to listExportRepository.save()
     // 1. For saving the "IN_PROGRESS" export
@@ -121,7 +123,7 @@ class ListExportServiceTest {
     when(listExportWorkerService.doAsyncExport(exportDetails))
       .thenReturn(CompletableFuture.failedFuture(new RuntimeException("something went wrong")));
 
-    listExportService.createExport(listId);
+    listExportService.createExport(listId, null);
 
     // Two calls made to listExportRepository.save()
     // 1. For saving the "IN_PROGRESS" export
@@ -244,7 +246,7 @@ class ListExportServiceTest {
     when(listExportMapper.toListExportDTO(exportDetails)).thenReturn(mock(ListExportDTO.class));
     when(listExportWorkerService.doAsyncExport(exportDetails)).thenReturn(CompletableFuture.completedFuture(null));
 
-    listExportService.createExport(listId);
+    listExportService.createExport(listId, null);
 
     verify(appShutdownService, times(1)).registerShutdownTask(eq(folioExecutionContext), any(Runnable.class), any(String.class));
   }


### PR DESCRIPTION
## Purpose
Accept list of fields to export in export request body. This will fix [MODLISTS-91](https://folio-org.atlassian.net/browse/MODLISTS-91) by allowing columns saved in local storage to be exported.

If there is no request body, then the fields from the list entity are used instead.
