### PR TITLE
MODLISTS-59 Add generic exception handler

### DIFF
--- a/src/test/java/org/folio/list/controller/ListExceptionHandlerTest.java
+++ b/src/test/java/org/folio/list/controller/ListExceptionHandlerTest.java
@@ -1,0 +1,45 @@
+package org.folio.list.controller;
+
+import org.folio.list.services.ListService;
+import org.folio.spring.integration.XOkapiHeaders;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ListController.class) // This is an arbitrary controller, just to get something to test with
+class ListExceptionHandlerTest {
+
+  private static final String TENANT_ID = "test-tenant";
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private ListService listService;
+
+  @Test
+  void handleGenericExceptions() throws Exception {
+    // Given a listId and a broken listService that always throws an unhandled exception
+    var listId = UUID.randomUUID();
+    doThrow(new RuntimeException()).when(listService).deleteList(listId);
+
+    // When we do a request that will cause an unhandled exception to get thrown
+    mockMvc.perform(delete("/lists/" + listId).header(XOkapiHeaders.TENANT, TENANT_ID))
+      // Then we expect a 500 Internal Server Error response with a mod-lists error code
+      .andExpect(status().isInternalServerError())
+      .andExpect(jsonPath("$.code", is("unhandled.error")));
+
+    // Sanity check to ensure that the unhandled exception came from the expectedg place
+    verify(listService, times(1)).deleteList(listId);
+  }
+}


### PR DESCRIPTION
## Purpose
Wrap unhandled exceptions in a generic wrapper, so that the UI can handle them better

## Approach
It adds a handler for all Exceptions, so that any without a more specific handler can still be handled