### PR TITLE
[MODLISTS-94] Check existing list of fields on list update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ build/
 
 ### VS Code ###
 .vscode/
+.env

--- a/src/main/java/org/folio/list/services/ListService.java
+++ b/src/main/java/org/folio/list/services/ListService.java
@@ -147,10 +147,10 @@ public class ListService {
         listContentsRepository.deleteContents(id);
         list.setSuccessRefresh(null);
       }
-      // Once UI has been updated to support sending fields in the request, the below if-block
-      // can be removed
+      // not all updates include a list of fields (e.g. just updating name/description)
+      // in this case, we do not want to modify the list of fields
       if (isEmpty(request.getFields())) {
-        request.setFields(getFieldsFromEntityType(entityType));
+        request.setFields(list.getFields());
       }
       String userFriendlyQuery = "";
       if (hasText(request.getFqlQuery())) {

--- a/src/test/java/org/folio/list/service/ListServiceTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceTest.java
@@ -358,15 +358,15 @@ class ListServiceTest {
     assertThat(oldVersion.getValue().getVersion()).isEqualTo(previousVersion+1);
   }
 
-  // This test can be removed once the UI has been updated to allow fields to be sent in the list update request
   @Test
-  void updateListShouldUseDefaultFieldsIfFieldsNotProvidedInRequest() {
+  void updateListShouldUseOriginalFieldsIfFieldsNotProvidedInRequest() {
     ListUpdateRequestDTO listUpdateRequestDto = TestDataFixture.getListUpdateRequestDTO();
     listUpdateRequestDto.setFields(null);
     UUID userId = UUID.randomUUID();
     UUID listId = UUID.randomUUID();
     String userFriendlyQuery = "some string";
-    List<String> expectedFields = List.of("field1");
+    // fields from the original ListEntity and NOT from the entity type
+    List<String> expectedFields = List.of("id", "item_status");
 
     User user = new User(userId, Optional.of(new UsersClient.Personal(FIRSTNAME, LASTNAME)));
     ListEntity entity = TestDataFixture.getListEntityWithSuccessRefresh(listId);


### PR DESCRIPTION
# [Jira MODLISTS-94](https://folio-org.atlassian.net/browse/MODLISTS-94)

## Purpose

Before, if a list was edited and no fields were included, we would add all fields to it. However, there are legitimate cases where a list could be edited and no fields included (e.g. just name/description); in these cases, we should use the list of fields from before the edit.