### PR TITLE
MODLISTS-104 Fix the condition values in Missing Items

### DIFF
--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -8,5 +8,6 @@
   <include file="changes/v1.0.1/changelog-v1.0.1.xml" relativeToChangelogFile="true"/>
   <include file="changes/v1.0.2/changelog-v1.0.2.xml" relativeToChangelogFile="true"/>
   <include file="changes/v1.1.0/changelog-v1.1.0.xml" relativeToChangelogFile="true"/>
+  <include file="changes/v1.1.1/changelog-v1.1.1.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.1.1/changelog-v1.1.1.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.1/changelog-v1.1.1.xml
@@ -1,0 +1,17 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+  <changeSet id="MODLISTS-104" author="mweaver@ebsco.com">
+    <comment>Convert the condition values in the Missing Items canned list to sentence case instead of lower case</comment>
+    <sql>
+      UPDATE list_details
+      SET fql_query = '{"item_status": {"$in": ["Missing", "Aged to lost", "Claimed returned", "Declared lost", "Long missing" ] }}'
+      WHERE id = '605a345f-f456-4ab2-8968-22f49cf1fbb6'
+        AND fql_query =
+            '{"item_status": {"$in": ["missing", "aged to lost", "claimed returned", "declared lost", "long missing" ] }}';
+    </sql>
+  </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
This fixes the Missing Items list by converting all of the condition values from lower case to sentence case, to match the available values provided in the Items entity type