### PR TITLE
MODLISTS-93: Include expected columns and data in list export

### DIFF
--- a/src/test/java/org/folio/list/service/export/CsvCreatorTest.java
+++ b/src/test/java/org/folio/list/service/export/CsvCreatorTest.java
@@ -65,7 +65,7 @@ class CsvCreatorTest {
     int numberOfBatch = 11;
 
     ListEntity entity = TestDataFixture.getPrivateListEntity();
-    EntityType entityType = createEntityType(List.of(createColumn("col1"), createColumn("col2")));
+    EntityType entityType = createEntityType(List.of(createColumn("id"), createColumn("item_status")));
     ExportDetails exportDetails = createExportDetails(entity, UUID.randomUUID());
     List<List<String>> contentIds = new ArrayList<>();
     // generate content ids for ten batches
@@ -74,8 +74,8 @@ class CsvCreatorTest {
     IntStream.rangeClosed(1, batchSize).forEach(i ->
       {
         LinkedHashMap<String, Object> linkedHashMap = new LinkedHashMap<>();
-        linkedHashMap.put("col1", "col1-value1");
-        linkedHashMap.put("col2", "col2-value1");
+        linkedHashMap.put("id", "value1");
+        linkedHashMap.put("item_status", "value2");
         contentsWithData.add(linkedHashMap);
       }
     );


### PR DESCRIPTION
## Purpose
[MODLISTS-93](https://folio-org.atlassian.net/browse/MODLISTS-93)

With this change, only selected columns will be exported (instead of exporting all columns, but only selected data)


<img width="1187" alt="Screenshot 2024-06-05 at 3 04 15 PM" src="https://github.com/folio-org/mod-lists/assets/97990858/4666f19f-67a0-4a9c-8fc5-e8506e8c4d7c">
