### PR TITLE
Always include ID columns in export

### DIFF
--- a/src/test/java/org/folio/list/service/export/ListExportServiceTest.java
+++ b/src/test/java/org/folio/list/service/export/ListExportServiceTest.java
@@ -3,14 +3,17 @@ package org.folio.list.service.export;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.folio.list.domain.AsyncProcessStatus;
 import org.folio.list.domain.ExportDetails;
@@ -21,6 +24,7 @@ import org.folio.list.exception.PrivateListOfAnotherUserException;
 import org.folio.list.mapper.ListExportMapper;
 import org.folio.list.repository.ListExportRepository;
 import org.folio.list.repository.ListRepository;
+import org.folio.list.rest.EntityTypeClient;
 import org.folio.list.services.AppShutdownService;
 import org.folio.list.services.ListActions;
 import org.folio.list.services.ListValidationService;
@@ -28,6 +32,8 @@ import org.folio.list.services.export.ExportUtils;
 import org.folio.list.services.export.ListExportService;
 import org.folio.list.services.export.ListExportWorkerService;
 import org.folio.list.utils.TestDataFixture;
+import org.folio.querytool.domain.dto.EntityType;
+import org.folio.querytool.domain.dto.EntityTypeColumn;
 import org.folio.s3.client.FolioS3Client;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.service.SystemUserScopedExecutionService;
@@ -74,11 +80,28 @@ class ListExportServiceTest {
   @Mock
   private SystemUserScopedExecutionService systemUserScopedExecutionService;
 
+  @Mock
+  private EntityTypeClient entityTypeClient;
+
   @Test
   void shouldSaveExport() {
     UUID listId = TestDataFixture.getListExportDetails().getList().getId();
     UUID userId = UUID.randomUUID();
-    List<String> fields = List.of("field1", "field2");
+    List<String> fields = new ArrayList<>(
+      List.of("field1", "field2")
+    );
+    List<String> expectedExportFields = List.of("field1", "field2", "field3");
+    List<EntityTypeColumn> entityTypeColumns =
+      new ArrayList<>(
+        List.of(
+          new EntityTypeColumn().name("field1").isIdColumn(true),
+          new EntityTypeColumn().name("field2"),
+          new EntityTypeColumn().name("field3").isIdColumn(true)
+        )
+      );
+    EntityType entityType = new EntityType()
+      .name("test-entity")
+      .columns(entityTypeColumns);
     ListEntity fetchedEntity = TestDataFixture.getListExportDetails().getList();
     ExportDetails exportDetails = TestDataFixture.getListExportDetails();
     ArgumentCaptor<ExportDetails> exportDetailsArgumentCaptor = ArgumentCaptor.forClass(ExportDetails.class);
@@ -89,11 +112,12 @@ class ListExportServiceTest {
       .thenReturn(mock(org.folio.list.domain.dto.ListExportDTO.class));
     when(folioExecutionContext.getUserId()).thenReturn(userId);
     when(listExportWorkerService.doAsyncExport(exportDetails)).thenReturn(CompletableFuture.completedFuture(true));
+    when(entityTypeClient.getEntityType(fetchedEntity.getEntityTypeId())).thenReturn(entityType);
     doAnswer(invocation -> {
-        Runnable runnable = invocation.getArgument(1);
-        runnable.run();
-        return CompletableFuture.completedFuture(null);
-      })
+      Runnable runnable = invocation.getArgument(1);
+      runnable.run();
+      return CompletableFuture.completedFuture(null);
+    })
       .when(systemUserScopedExecutionService)
       .executeAsyncSystemUserScoped(any(), any());
 
@@ -109,6 +133,7 @@ class ListExportServiceTest {
     assertThat(listId).isEqualTo(inProgressExport.getList().getId());
     assertThat(inProgressExport.getStartDate()).isNotNull();
     assertThat(inProgressExport.getStatus()).hasToString(ListExportDTO.StatusEnum.IN_PROGRESS.toString());
+    assertTrue(inProgressExport.getFields().containsAll(expectedExportFields));
 
     assertThat(exportDetails.getCreatedBy()).isEqualTo(successExport.getCreatedBy());
     assertThat(exportDetails.getList().getId()).isEqualTo(successExport.getList().getId());
@@ -116,6 +141,7 @@ class ListExportServiceTest {
     assertThat(successExport.getEndDate()).isNotNull();
     assertThat(successExport.getStatus()).hasToString(ListExportDTO.StatusEnum.SUCCESS.toString());
   }
+
 
   @Test
   void shouldSaveFailedExportIfRefreshFail() {
@@ -126,6 +152,7 @@ class ListExportServiceTest {
     ArgumentCaptor<ExportDetails> exportDetailsArgumentCaptor = ArgumentCaptor.forClass(ExportDetails.class);
     when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(fetchedEntity));
     when(listExportRepository.save(exportDetailsArgumentCaptor.capture())).thenReturn(exportDetails);
+    when(entityTypeClient.getEntityType(fetchedEntity.getEntityTypeId())).thenReturn(new EntityType());
 
     when(listExportMapper.toListExportDTO(any(ExportDetails.class)))
       .thenReturn(mock(org.folio.list.domain.dto.ListExportDTO.class));
@@ -133,10 +160,10 @@ class ListExportServiceTest {
     when(listExportWorkerService.doAsyncExport(exportDetails))
       .thenReturn(CompletableFuture.failedFuture(new RuntimeException("something went wrong")));
     doAnswer(invocation -> {
-        Runnable runnable = invocation.getArgument(1);
-        runnable.run();
-        return CompletableFuture.completedFuture(null);
-      })
+      Runnable runnable = invocation.getArgument(1);
+      runnable.run();
+      return CompletableFuture.completedFuture(null);
+    })
       .when(systemUserScopedExecutionService)
       .executeAsyncSystemUserScoped(any(), any());
 
@@ -267,6 +294,7 @@ class ListExportServiceTest {
     when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(fetchedEntity));
     when(listExportRepository.save(any(ExportDetails.class))).thenReturn(exportDetails);
     when(listExportMapper.toListExportDTO(exportDetails)).thenReturn(mock(ListExportDTO.class));
+    when(entityTypeClient.getEntityType(fetchedEntity.getEntityTypeId())).thenReturn(new EntityType());
 
     listExportService.createExport(listId, null);
 


### PR DESCRIPTION
## Purpose
Solving a bug introduced in [MODLISTS-93](https://folio-org.atlassian.net/browse/MODLISTS-93). Always include all ID columns in export so that export can complete without errors.