### PR TITLE
getAllLists: return empty list summary when searchEntityTypeIds is empty

### DIFF
--- a/src/main/java/org/folio/list/services/ListService.java
+++ b/src/main/java/org/folio/list/services/ListService.java
@@ -96,6 +96,11 @@ public class ListService {
       .stream()
       .filter(id -> isEmpty(entityTypeIds) || entityTypeIds.contains(id))
       .toList();
+    if (isEmpty(searchEntityTypeIds)) {
+      return new ListSummaryResultsDTO()
+        .totalRecords(0L)
+        .totalPages(0);
+    }
 
     Page<ListEntity> lists = listRepository.searchList(
       pageable,

--- a/src/test/java/org/folio/list/service/ListServiceTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceTest.java
@@ -208,6 +208,24 @@ class ListServiceTest {
   }
 
   @Test
+  void getAllListsShouldReturnEmptyPageForEmptySearchEntityTypeIds() {
+    UUID currentUserId = UUID.randomUUID();
+    when(executionContext.getUserId()).thenReturn(currentUserId);
+    when(entityTypeClient.getEntityTypeSummary(null)).thenReturn(List.of());
+    Page<ListSummaryDTO> expected = new PageImpl<>(List.of());
+    var actual = listService.getAllLists(
+      Pageable.ofSize(100),
+      List.of(UUID.randomUUID(), UUID.randomUUID()),
+      null,
+      true,
+      false,
+      false,
+      null
+    );
+    assertThat(actual.getContent()).isEqualTo(expected.getContent());
+  }
+
+  @Test
   void testCreateList() {
     ListRequestDTO listRequestDto = TestDataFixture.getListRequestDTO();
     UUID userId = UUID.randomUUID();


### PR DESCRIPTION
## Purpose
GET /lists throws a 500 if there are no valid entity types available to the user. Fix this by just returning an empty page in this scenario.
