### PR TITLE
MODLISTS-136: rename the permission "lists.item.refresh" according to…

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -44,7 +44,7 @@
         }, {
           "methods": ["POST"],
           "pathPattern": "/lists/{id}/refresh",
-          "permissionsRequired": ["lists.item.refresh"],
+          "permissionsRequired": ["lists.item.post"],
           "modulePermissions": ["users.item.get"]
         }, {
           "methods": ["DELETE"],
@@ -123,7 +123,8 @@
       "description": "Get the contents of a list"
     },
     {
-      "permissionName": "lists.item.refresh",
+      "permissionName": "lists.item.post",
+      "replaces":  ["lists.item.refresh"],
       "displayName": "Lists: Refresh a list",
       "description": "Refresh a list"
     },


### PR DESCRIPTION
… permission name convention

https://folio-org.atlassian.net/wiki/spaces/FOLIJET/pages/156368925/Permissions+naming+convention

## Purpose
_Describe the purpose of the pull request. Include background information if necessary._

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
