### PR TITLE
[MODLISTS-126] Invoke migration methods on install and GET /lists

### DIFF
--- a/src/main/java/org/folio/list/mapper/ListMigrationMapper.java
+++ b/src/main/java/org/folio/list/mapper/ListMigrationMapper.java
@@ -3,7 +3,7 @@ package org.folio.list.mapper;
 import java.time.Instant;
 import java.util.stream.Collectors;
 import org.folio.list.domain.ListEntity;
-import org.folio.list.services.ListService;
+import org.folio.list.services.UserFriendlyQueryService;
 import org.folio.querytool.domain.dto.FqmMigrateRequest;
 import org.folio.querytool.domain.dto.FqmMigrateResponse;
 import org.folio.querytool.domain.dto.FqmMigrateWarning;
@@ -20,7 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 @Mapper(
   componentModel = MappingConstants.ComponentModel.SPRING,
   injectionStrategy = InjectionStrategy.CONSTRUCTOR,
-  uses = TranslationService.class
+  uses = { TranslationService.class, UserFriendlyQueryService.class }
 )
 // we cannot use constructor injection in the subclass due to https://github.com/mapstruct/mapstruct/issues/2257
 // and we cannot use an interface here, due to the @AfterMapping.
@@ -29,10 +29,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 public abstract class ListMigrationMapper {
 
   @Autowired
-  private ListService listService;
+  private TranslationService translationService;
 
   @Autowired
-  private TranslationService translationService;
+  private UserFriendlyQueryService userFriendlyQueryService;
 
   public abstract FqmMigrateRequest toMigrationRequest(ListEntity list);
 
@@ -48,7 +48,7 @@ public abstract class ListMigrationMapper {
   // instead, we have to do this at the end and manually implement this mapping :/
   @AfterMapping
   protected void updateListDescriptionAfterMigration(@MappingTarget ListEntity list, FqmMigrateResponse response) {
-    listService.updateUserFriendlyQuery(list);
+    userFriendlyQueryService.updateListUserFriendlyQuery(list);
 
     if (response.getWarnings().isEmpty()) {
       return;

--- a/src/main/java/org/folio/list/rest/EntityTypeClient.java
+++ b/src/main/java/org/folio/list/rest/EntityTypeClient.java
@@ -1,14 +1,17 @@
 package org.folio.list.rest;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import feign.FeignException;
+import java.util.List;
+import java.util.UUID;
+import org.folio.list.exception.InsufficientEntityTypePermissionsException;
+import org.folio.list.services.ListActions;
 import org.folio.querytool.domain.dto.EntityType;
+import org.folio.spring.exception.NotFoundException;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
-
-import java.util.List;
-import java.util.UUID;
 
 @FeignClient(name = "entity-types")
 public interface EntityTypeClient {
@@ -17,6 +20,18 @@ public interface EntityTypeClient {
 
   @GetMapping("/{entityTypeId}")
   EntityType getEntityType(@RequestHeader UUID entityTypeId);
+
+  /** Gets an entity type; includes wrappers for feign exceptions */
+  default EntityType getEntityType(UUID entityTypeId, ListActions attemptedAction) {
+    try {
+      return getEntityType(entityTypeId);
+    } catch (FeignException.Unauthorized e) {
+      String message = e.getMessage();
+      throw new InsufficientEntityTypePermissionsException(entityTypeId, attemptedAction, message);
+    } catch (FeignException.NotFound e) {
+      throw new NotFoundException("Entity type with id " + entityTypeId + " was not found.");
+    }
+  }
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   record EntityTypeSummary(UUID id, String label) {}

--- a/src/main/java/org/folio/list/services/CustomTenantService.java
+++ b/src/main/java/org/folio/list/services/CustomTenantService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class CustomTenantService extends TenantService {
 
+  protected final MigrationService migrationService;
   protected final PrepareSystemUserService prepareSystemUserService;
 
   @Autowired
@@ -23,9 +24,11 @@ public class CustomTenantService extends TenantService {
     JdbcTemplate jdbcTemplate,
     FolioExecutionContext context,
     FolioSpringLiquibase folioSpringLiquibase,
+    MigrationService migrationService,
     PrepareSystemUserService prepareSystemUserService
   ) {
     super(jdbcTemplate, context, folioSpringLiquibase);
+    this.migrationService = migrationService;
     this.prepareSystemUserService = prepareSystemUserService;
   }
 
@@ -33,5 +36,8 @@ public class CustomTenantService extends TenantService {
   protected void afterTenantUpdate(TenantAttributes tenantAttributes) {
     log.info("Initializing system user");
     prepareSystemUserService.setupSystemUser();
+
+    log.info("Verifying lists are up to date");
+    migrationService.verifyListsAreUpToDate();
   }
 }

--- a/src/main/java/org/folio/list/services/ListValidationService.java
+++ b/src/main/java/org/folio/list/services/ListValidationService.java
@@ -1,6 +1,5 @@
 package org.folio.list.services;
 
-import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import org.folio.fql.service.FqlValidationService;
 import org.folio.list.domain.AsyncProcessStatus;
@@ -14,7 +13,6 @@ import org.folio.list.repository.ListExportRepository;
 import org.folio.list.rest.EntityTypeClient;
 import org.folio.querytool.domain.dto.EntityType;
 import org.folio.spring.FolioExecutionContext;
-import org.folio.spring.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -165,12 +163,6 @@ public class ListValidationService {
   }
 
   private void assertUserHasEntityTypePermissions(UUID entityTypeId, ListActions failedAction) {
-    try {
-      entityTypeClient.getEntityType(entityTypeId);
-    } catch(FeignException.Unauthorized e) {
-      throw new InsufficientEntityTypePermissionsException(entityTypeId, failedAction, e.getMessage());
-    } catch(FeignException.NotFound e) {
-      throw new NotFoundException("Entity type with id " + entityTypeId + " was not found.");
-    }
+    entityTypeClient.getEntityType(entityTypeId, failedAction);
   }
 }

--- a/src/main/java/org/folio/list/services/MigrationService.java
+++ b/src/main/java/org/folio/list/services/MigrationService.java
@@ -77,6 +77,7 @@ public class MigrationService {
   public void verifyListsAreUpToDate(String latestVersion) {
     String currentVersion = latestMigratedVersionRepository.getLatestMigratedVersion();
     if (currentVersion.equals(latestVersion)) {
+      log.info("Lists are up to date!");
       return;
     }
 

--- a/src/main/java/org/folio/list/services/export/CsvCreator.java
+++ b/src/main/java/org/folio/list/services/export/CsvCreator.java
@@ -55,7 +55,7 @@ public class CsvCreator {
     var localStorage = new ExportLocalStorage(exportDetails.getExportId());
     ListEntity list = exportDetails.getList();
     var idsProvider = new ListIdsProvider(contentsRepository, list);
-    EntityType entityType = entityTypeClient.getEntityType(list.getEntityTypeId());
+    EntityType entityType = entityTypeClient.getEntityType(list.getEntityTypeId(), ListActions.EXPORT);
 
     OutputStream localStorageOutputStream = localStorage.outputStream();
     var csvWriter = new ListCsvWriter(entityType, exportDetails.getFields());

--- a/src/main/java/org/folio/list/services/export/ListExportService.java
+++ b/src/main/java/org/folio/list/services/export/ListExportService.java
@@ -26,7 +26,6 @@ import org.folio.list.services.AppShutdownService;
 import org.folio.list.services.AppShutdownService.ShutdownTask;
 import org.folio.list.services.ListActions;
 import org.folio.list.services.ListValidationService;
-import org.folio.querytool.domain.dto.EntityTypeColumn;
 import org.folio.s3.client.FolioS3Client;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.service.SystemUserScopedExecutionService;
@@ -59,7 +58,7 @@ public class ListExportService {
     validationService.validateCreateExport(list);
     List<String> fieldsToExport = isEmpty(fields) ? list.getFields() : fields;
     entityTypeClient
-      .getEntityType(list.getEntityTypeId())
+      .getEntityType(list.getEntityTypeId(), ListActions.EXPORT)
       .getColumns()
       .stream()
       .filter(column -> Boolean.TRUE.equals(column.getIsIdColumn()))

--- a/src/test/java/org/folio/list/mapper/ListMigrationMapperTest.java
+++ b/src/test/java/org/folio/list/mapper/ListMigrationMapperTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.UUID;
 import org.folio.list.domain.ListEntity;
-import org.folio.list.services.ListService;
+import org.folio.list.services.UserFriendlyQueryService;
 import org.folio.list.utils.TestDataFixture;
 import org.folio.querytool.domain.dto.FqmMigrateRequest;
 import org.folio.querytool.domain.dto.FqmMigrateResponse;
@@ -26,10 +26,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ListMigrationMapperTest {
 
   @Mock
-  private ListService listService;
+  private TranslationService translationService;
 
   @Mock
-  private TranslationService translationService;
+  private UserFriendlyQueryService userFriendlyQueryService;
 
   @InjectMocks
   private ListMigrationMapper mapper = new ListMigrationMapperImpl();
@@ -53,8 +53,8 @@ class ListMigrationMapperTest {
         list.setUserFriendlyQuery(list.getFqlQuery());
         return list;
       })
-      .when(listService)
-      .updateUserFriendlyQuery(any());
+      .when(userFriendlyQueryService)
+      .updateListUserFriendlyQuery(any());
 
     FqmMigrateResponse response = new FqmMigrateResponse()
       .entityTypeId(UUID.fromString("7c3f9133-bda0-5206-944a-a7a2c2bbff80"))
@@ -82,8 +82,8 @@ class ListMigrationMapperTest {
         list.setUserFriendlyQuery(list.getFqlQuery());
         return list;
       })
-      .when(listService)
-      .updateUserFriendlyQuery(any());
+      .when(userFriendlyQueryService)
+      .updateListUserFriendlyQuery(any());
 
     FqmMigrateResponse response = new FqmMigrateResponse()
       .entityTypeId(UUID.fromString("7c3f9133-bda0-5206-944a-a7a2c2bbff80"))
@@ -114,8 +114,8 @@ class ListMigrationMapperTest {
         list.setUserFriendlyQuery(list.getFqlQuery());
         return list;
       })
-      .when(listService)
-      .updateUserFriendlyQuery(any());
+      .when(userFriendlyQueryService)
+      .updateListUserFriendlyQuery(any());
 
     FqmMigrateResponse response = new FqmMigrateResponse()
       .entityTypeId(UUID.fromString("7c3f9133-bda0-5206-944a-a7a2c2bbff80"))

--- a/src/test/java/org/folio/list/rest/EntityTypeClientTest.java
+++ b/src/test/java/org/folio/list/rest/EntityTypeClientTest.java
@@ -1,0 +1,62 @@
+package org.folio.list.rest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import feign.FeignException;
+import java.util.UUID;
+import org.folio.list.exception.InsufficientEntityTypePermissionsException;
+import org.folio.list.services.ListActions;
+import org.folio.list.utils.TestDataFixture;
+import org.folio.querytool.domain.dto.EntityType;
+import org.folio.spring.exception.NotFoundException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EntityTypeClientTest {
+
+  private static final EntityType ENTITY_TYPE = TestDataFixture.TEST_ENTITY_TYPE;
+  private static final UUID ENTITY_TYPE_ID = UUID.fromString(ENTITY_TYPE.getId());
+
+  @Spy
+  private EntityTypeClient entityTypeClient;
+
+  @Test
+  void testReturnsOnSuccess() {
+    when(entityTypeClient.getEntityType(ENTITY_TYPE_ID)).thenReturn(ENTITY_TYPE);
+
+    assertThat(entityTypeClient.getEntityType(ENTITY_TYPE_ID, ListActions.READ), is(ENTITY_TYPE));
+  }
+
+  @Test
+  void testHandlesUnauthorized() {
+    when(entityTypeClient.getEntityType(ENTITY_TYPE_ID))
+      .thenThrow(
+        new FeignException.Unauthorized(
+          "[{\"User is missing permissions: [foo.bar]\"}]",
+          mock(feign.Request.class),
+          null,
+          null
+        )
+      );
+
+    assertThrows(
+      InsufficientEntityTypePermissionsException.class,
+      () -> entityTypeClient.getEntityType(ENTITY_TYPE_ID, ListActions.READ)
+    );
+  }
+
+  @Test
+  void testHandlesNotFound() {
+    when(entityTypeClient.getEntityType(ENTITY_TYPE_ID))
+      .thenThrow(new FeignException.NotFound("Entity type not found", mock(feign.Request.class), null, null));
+
+    assertThrows(NotFoundException.class, () -> entityTypeClient.getEntityType(ENTITY_TYPE_ID, ListActions.READ));
+  }
+}

--- a/src/test/java/org/folio/list/service/CustomTenantServiceTest.java
+++ b/src/test/java/org/folio/list/service/CustomTenantServiceTest.java
@@ -4,6 +4,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import org.folio.list.services.CustomTenantService;
+import org.folio.list.services.MigrationService;
 import org.folio.spring.service.PrepareSystemUserService;
 import org.folio.tenant.domain.dto.TenantAttributes;
 import org.junit.jupiter.api.Test;
@@ -21,10 +22,14 @@ class CustomTenantServiceTest {
   @Mock
   private PrepareSystemUserService prepareSystemUserService;
 
+  @Mock
+  private MigrationService migrationService;
+
   @Test
-  void testSystemUserCreation() {
+  void testTenantInstallTasks() {
     customTenantService.createOrUpdateTenant(new TenantAttributes());
 
     verify(prepareSystemUserService, times(1)).setupSystemUser();
+    verify(migrationService, times(1)).verifyListsAreUpToDate();
   }
 }

--- a/src/test/java/org/folio/list/service/ListServiceGetListContentsTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceGetListContentsTest.java
@@ -141,7 +141,7 @@ class ListServiceGetListContentsTest {
     expectedEntity.getSuccessRefresh().setRecordsCount(2);
 
     when(executionContext.getTenantId()).thenReturn(tenantId);
-    when(entityTypeClient.getEntityType(entityTypeId)).thenReturn(entityType);
+    when(entityTypeClient.getEntityType(entityTypeId, ListActions.READ)).thenReturn(entityType);
     when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(expectedEntity));
     when(listContentsRepository.getContents(listId, successRefresh.getId(), new OffsetRequest(offset, size))).thenReturn(listContents);
     when(queryClient.getContents(contentsRequest)).thenReturn(expectedList);

--- a/src/test/java/org/folio/list/service/ListServiceValidateCancelExportTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceValidateCancelExportTest.java
@@ -6,6 +6,7 @@ import org.folio.list.domain.ListEntity;
 import org.folio.list.exception.ExportNotFoundException;
 import org.folio.list.exception.PrivateListOfAnotherUserException;
 import org.folio.list.rest.EntityTypeClient;
+import org.folio.list.services.ListActions;
 import org.folio.list.services.ListValidationService;
 import org.folio.list.utils.TestDataFixture;
 import org.folio.spring.FolioExecutionContext;
@@ -37,7 +38,7 @@ class ListServiceValidateCancelExportTest {
     list.setIsPrivate(true);
     UUID userId = list.getCreatedBy();
     when(folioExecutionContext.getUserId()).thenReturn(userId);
-    when(entityTypeClient.getEntityType(list.getEntityTypeId())).thenReturn(TestDataFixture.TEST_ENTITY_TYPE);
+    when(entityTypeClient.getEntityType(list.getEntityTypeId(), ListActions.CANCEL_EXPORT)).thenReturn(TestDataFixture.TEST_ENTITY_TYPE);
     assertDoesNotThrow(() -> validationService.validateCancelExport(exportDetails));
   }
 
@@ -47,7 +48,7 @@ class ListServiceValidateCancelExportTest {
     ListEntity list = exportDetails.getList();
     list.setIsPrivate(true);
     when(folioExecutionContext.getUserId()).thenReturn(UUID.randomUUID());
-    when(entityTypeClient.getEntityType(list.getEntityTypeId())).thenReturn(TestDataFixture.TEST_ENTITY_TYPE);
+    when(entityTypeClient.getEntityType(list.getEntityTypeId(), ListActions.CANCEL_EXPORT)).thenReturn(TestDataFixture.TEST_ENTITY_TYPE);
     assertThrows(PrivateListOfAnotherUserException.class, () -> validationService.validateCancelExport(exportDetails));
   }
 

--- a/src/test/java/org/folio/list/service/ListServiceValidateReadTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceValidateReadTest.java
@@ -1,14 +1,11 @@
 package org.folio.list.service;
 
-import feign.FeignException;
 import org.folio.list.domain.ListEntity;
-import org.folio.list.exception.InsufficientEntityTypePermissionsException;
 import org.folio.list.exception.PrivateListOfAnotherUserException;
 import org.folio.list.rest.EntityTypeClient;
 import org.folio.list.services.ListValidationService;
 import org.folio.list.utils.TestDataFixture;
 import org.folio.spring.FolioExecutionContext;
-import org.folio.spring.exception.NotFoundException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -19,7 +16,6 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,22 +31,6 @@ class ListServiceValidateReadTest {
   void shouldValidateRead() {
     ListEntity entity = TestDataFixture.getListEntityWithoutQuery();
     assertDoesNotThrow(() -> validationService.validateRead(entity));
-  }
-
-  @Test
-  void validateReadShouldThrowErrorForUserMissingPermissions() {
-    ListEntity entity = TestDataFixture.getListEntityWithoutQuery();
-    when(entityTypeClient.getEntityType(entity.getEntityTypeId()))
-      .thenThrow(new FeignException.Unauthorized("[{\"User is missing permissions: [foo.bar]\"}]", mock(feign.Request.class), null, null));
-    assertThrows(InsufficientEntityTypePermissionsException.class, () -> validationService.validateRead(entity));
-  }
-
-  @Test
-  void validateReadShouldThrowErrorForMissingEntityType() {
-    ListEntity entity = TestDataFixture.getListEntityWithoutQuery();
-    when(entityTypeClient.getEntityType(entity.getEntityTypeId()))
-      .thenThrow(new FeignException.NotFound("Entity type not found", mock(feign.Request.class), null, null));
-    assertThrows(NotFoundException.class, () -> validationService.validateRead(entity));
   }
 
   @Test

--- a/src/test/java/org/folio/list/service/export/CsvCreatorTest.java
+++ b/src/test/java/org/folio/list/service/export/CsvCreatorTest.java
@@ -9,6 +9,7 @@ import org.folio.list.repository.ListContentsRepository;
 import org.folio.list.repository.ListExportRepository;
 import org.folio.list.rest.EntityTypeClient;
 import org.folio.list.rest.QueryClient;
+import org.folio.list.services.ListActions;
 import org.folio.list.services.export.CsvCreator;
 import org.folio.list.services.export.ExportLocalStorage;
 import org.folio.list.utils.TestDataFixture;
@@ -93,7 +94,7 @@ class CsvCreatorTest {
           .toList()));
 
     when(exportProperties.getBatchSize()).thenReturn(batchSize);
-    when(entityTypeClient.getEntityType(entity.getEntityTypeId())).thenReturn(entityType);
+    when(entityTypeClient.getEntityType(entity.getEntityTypeId(), ListActions.EXPORT)).thenReturn(entityType);
 
 
     when(listExportRepository.findById(exportDetails.getExportId())).thenReturn(Optional.of(exportDetails));

--- a/src/test/java/org/folio/list/service/export/ListExportServiceTest.java
+++ b/src/test/java/org/folio/list/service/export/ListExportServiceTest.java
@@ -112,7 +112,7 @@ class ListExportServiceTest {
       .thenReturn(mock(org.folio.list.domain.dto.ListExportDTO.class));
     when(folioExecutionContext.getUserId()).thenReturn(userId);
     when(listExportWorkerService.doAsyncExport(exportDetails)).thenReturn(CompletableFuture.completedFuture(true));
-    when(entityTypeClient.getEntityType(fetchedEntity.getEntityTypeId())).thenReturn(entityType);
+    when(entityTypeClient.getEntityType(fetchedEntity.getEntityTypeId(), ListActions.EXPORT)).thenReturn(entityType);
     doAnswer(invocation -> {
       Runnable runnable = invocation.getArgument(1);
       runnable.run();
@@ -152,7 +152,7 @@ class ListExportServiceTest {
     ArgumentCaptor<ExportDetails> exportDetailsArgumentCaptor = ArgumentCaptor.forClass(ExportDetails.class);
     when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(fetchedEntity));
     when(listExportRepository.save(exportDetailsArgumentCaptor.capture())).thenReturn(exportDetails);
-    when(entityTypeClient.getEntityType(fetchedEntity.getEntityTypeId())).thenReturn(new EntityType());
+    when(entityTypeClient.getEntityType(fetchedEntity.getEntityTypeId(), ListActions.EXPORT)).thenReturn(new EntityType());
 
     when(listExportMapper.toListExportDTO(any(ExportDetails.class)))
       .thenReturn(mock(org.folio.list.domain.dto.ListExportDTO.class));
@@ -294,7 +294,7 @@ class ListExportServiceTest {
     when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(fetchedEntity));
     when(listExportRepository.save(any(ExportDetails.class))).thenReturn(exportDetails);
     when(listExportMapper.toListExportDTO(exportDetails)).thenReturn(mock(ListExportDTO.class));
-    when(entityTypeClient.getEntityType(fetchedEntity.getEntityTypeId())).thenReturn(new EntityType());
+    when(entityTypeClient.getEntityType(fetchedEntity.getEntityTypeId(), ListActions.EXPORT)).thenReturn(new EntityType());
 
     listExportService.createExport(listId, null);
 


### PR DESCRIPTION
It was all fun and games, but then:

![image](https://github.com/user-attachments/assets/8bd657d6-fd7a-4beb-bb59-90ba2aa409ff)

I had to do a bit of refactoring to solve this, which IMO is an overall improvement. Two main things were done as part of this:

- convenience methods for getting user friendly queries for `ListEntity`s (rather than just FqlConditions) were moved to `UserFriendlyQueryService`
- wrapped versions of `EntityTypeClient.getEntityType` which include specific exception handling (for not found, permissions, etc) were consolidated into a new overloaded method inside `EntityTypeClient`. This improves complexity for this error handling across several locations, and enables all parts of the code to easily leverage this.