### PR TITLE
MODLISTS-155 MODFQMMGR-550 Add retry logic to tenant initialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <awaitility.version>4.2.0</awaitility.version>
     <snakeyaml.version>2.0</snakeyaml.version>
     <snappy-java.version>1.1.10.5</snappy-java.version>
+    <spring-retry.version>2.0.10</spring-retry.version>
 
     <!-- test dependencies -->
     <testcontainers.version>1.17.6</testcontainers.version>
@@ -168,6 +169,12 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-messaging</artifactId>
       <version>6.1.6</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.retry</groupId>
+      <artifactId>spring-retry</artifactId>
+      <version>${spring-retry.version}</version>
     </dependency>
 
     <!-- AWS S3 dependencies -->

--- a/src/main/java/org/folio/list/services/CustomTenantService.java
+++ b/src/main/java/org/folio/list/services/CustomTenantService.java
@@ -1,6 +1,7 @@
 package org.folio.list.services;
 
 import lombok.extern.log4j.Log4j2;
+import org.folio.list.exception.InsufficientEntityTypePermissionsException;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.liquibase.FolioSpringLiquibase;
 import org.folio.spring.service.PrepareSystemUserService;
@@ -9,7 +10,11 @@ import org.folio.tenant.domain.dto.TenantAttributes;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 
 @Log4j2
 @Primary
@@ -37,7 +42,22 @@ public class CustomTenantService extends TenantService {
     log.info("Initializing system user");
     prepareSystemUserService.setupSystemUser();
 
-    log.info("Verifying lists are up to date");
-    migrationService.verifyListsAreUpToDate();
+    // In Eureka, the system user often takes a short bit of time for its permissions to be assigned, so retry in the
+    // case of failures related to missing permissions
+    RetryTemplate.builder()
+      .retryOn(InsufficientEntityTypePermissionsException.class)
+      .exponentialBackoff(Duration.of(2, ChronoUnit.SECONDS), 1.5, Duration.of(1, ChronoUnit.MINUTES))
+      .withTimeout(Duration.of(2, ChronoUnit.MINUTES))
+      .build()
+      .execute(ctx -> {
+        log.info("Verifying lists are up to date. Attempt #" + (ctx.getRetryCount() + 1));
+        migrationService.verifyListsAreUpToDate();
+        return null;
+      }, ctx -> {
+        log.error("Unable to verify lists are up to date", ctx.getLastThrowable());
+        // This RetryTemplate only deals with InsufficientEntityTypePermissionsException, so we know that's what this
+        // Throwable really is. Rethrow it to fail the tenant update process.
+        throw (InsufficientEntityTypePermissionsException) ctx.getLastThrowable();
+      });
   }
 }

--- a/src/test/java/org/folio/list/service/CustomTenantServiceTest.java
+++ b/src/test/java/org/folio/list/service/CustomTenantServiceTest.java
@@ -1,9 +1,12 @@
 package org.folio.list.service;
 
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
+import org.folio.list.exception.InsufficientEntityTypePermissionsException;
 import org.folio.list.services.CustomTenantService;
+import org.folio.list.services.ListActions;
 import org.folio.list.services.MigrationService;
 import org.folio.spring.service.PrepareSystemUserService;
 import org.folio.tenant.domain.dto.TenantAttributes;
@@ -12,6 +15,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @ExtendWith(MockitoExtension.class)
 class CustomTenantServiceTest {
@@ -32,4 +41,27 @@ class CustomTenantServiceTest {
     verify(prepareSystemUserService, times(1)).setupSystemUser();
     verify(migrationService, times(1)).verifyListsAreUpToDate();
   }
+
+  @Test
+  void testMigrationErrorRetry() {
+    // Given a retryable migration error that fails for the first 5 seconds, then succeeds
+    Instant finishTime = Instant.now().plus(5, ChronoUnit.SECONDS); // This needs to be greater than the max timeout on the retryTemplate in CustomTenantService
+    AtomicInteger attempts = new AtomicInteger(0);
+    doAnswer(invocation -> {
+      attempts.incrementAndGet();
+      if (Instant.now().isAfter(finishTime)) {
+        return null;
+      }
+      throw new InsufficientEntityTypePermissionsException(UUID.randomUUID(), ListActions.UPDATE, "User is missing permissions [{\"missing permission\"]}");
+    }).when(migrationService).verifyListsAreUpToDate();
+
+    // When the tenant is installed
+    customTenantService.createOrUpdateTenant(new TenantAttributes());
+
+    // Then the migration should be retried until it succeeds
+    // Verify that we didn't get any unexpected calls to the migration service and that it retried at least once
+    verify(migrationService, times(attempts.get())).verifyListsAreUpToDate();
+    assertTrue(attempts.get() > 1, "Expected migration to be retried at least once");
+  }
+
 }


### PR DESCRIPTION
This commit adds retry logic to the tenant initialization service, around the query migration operation, since the necessary permissions on the system user can take a bit of time when initially creating a eureka tenant
