### PR TITLE
MODLISTS-158: Retry failed S3 uploads during export

### DIFF
--- a/src/main/java/org/folio/list/configuration/SystemUserFeignConfig.java
+++ b/src/main/java/org/folio/list/configuration/SystemUserFeignConfig.java
@@ -1,0 +1,17 @@
+package org.folio.list.configuration;
+
+import feign.Client;
+import okhttp3.OkHttpClient;
+import org.folio.list.rest.SystemUserClient;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.service.SystemUserService;
+import org.springframework.context.annotation.Bean;
+
+public class SystemUserFeignConfig {
+
+  @Bean
+  public Client feignClient(FolioExecutionContext executionContext, SystemUserService systemUserService) {
+    return new SystemUserClient(executionContext, systemUserService, new OkHttpClient());
+  }
+}
+

--- a/src/main/java/org/folio/list/rest/SystemUserClient.java
+++ b/src/main/java/org/folio/list/rest/SystemUserClient.java
@@ -1,0 +1,71 @@
+package org.folio.list.rest;
+
+import feign.Client;
+import feign.Request;
+import feign.Response;
+import feign.okhttp.OkHttpClient;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.model.SystemUser;
+import org.folio.spring.service.SystemUserService;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Log4j2
+public class SystemUserClient implements Client {
+
+  private final FolioExecutionContext executionContext;
+  private final SystemUserService systemUserService;
+  private final OkHttpClient delegate;
+
+  public SystemUserClient(FolioExecutionContext executionContext, SystemUserService systemUserService, okhttp3.OkHttpClient okHttpClient) {
+    this.executionContext = executionContext;
+    this.systemUserService = systemUserService;
+    this.delegate = new OkHttpClient(okHttpClient);
+  }
+
+  public Response execute(Request request, Request.Options options) throws IOException {
+    String url = prepareUrl(request.url(), this.executionContext);
+    Map<String, Collection<String>> allHeaders = prepareHeaders(request, this.executionContext);
+    Request requestWithUrl = Request.create(request.httpMethod(), url, allHeaders, request.body(), request.charset(), request.requestTemplate());
+    log.debug("FolioExecutionContext: {};\nPrepared the Feign Client Request: {} with headers {};\nCurrent thread: {}", this.executionContext, requestWithUrl, allHeaders, Thread.currentThread().getName());
+    return this.delegate.execute(requestWithUrl, options);
+  }
+
+  static String prepareUrl(String requestUrl, FolioExecutionContext context) {
+    String okapiUrl = context.getOkapiUrl();
+    if (okapiUrl == null) {
+      return requestUrl;
+    } else {
+      okapiUrl = StringUtils.appendIfMissing(okapiUrl, "/");
+      return requestUrl.replace("http://", okapiUrl);
+    }
+  }
+
+  Map<String, Collection<String>> prepareHeaders(Request request, FolioExecutionContext context) {
+    Map<String, Collection<String>> allHeaders = new HashMap<>(request.headers());
+    Map<String, Collection<String>> okapiHeaders = new HashMap<>(context.getOkapiHeaders());
+    String okapiTenant = okapiHeaders
+      .getOrDefault("x-okapi-tenant", List.of())
+      .stream()
+      .findFirst()
+      .orElse(null);
+    if (okapiTenant != null) {
+      SystemUser authedSystemUser = systemUserService.getAuthedSystemUser(okapiTenant);
+      okapiHeaders.put("x-okapi-token", List.of(authedSystemUser.token().accessToken()));
+    }
+    allHeaders.putAll(okapiHeaders);
+    context.getAllHeaders()
+      .keySet()
+      .stream()
+      .filter("Accept-Language"::equalsIgnoreCase)
+      .findFirst()
+      .map(key -> context.getAllHeaders().get(key)).ifPresent(values -> allHeaders.put("Accept-Language", values));
+    return allHeaders;
+  }
+}

--- a/src/main/java/org/folio/list/rest/SystemUserQueryClient.java
+++ b/src/main/java/org/folio/list/rest/SystemUserQueryClient.java
@@ -1,0 +1,17 @@
+package org.folio.list.rest;
+
+import org.folio.list.configuration.SystemUserFeignConfig;
+import org.folio.querytool.domain.dto.ContentsRequest;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+import java.util.Map;
+
+@FeignClient(name = "query/contents/privileged", configuration = SystemUserFeignConfig.class)
+public interface SystemUserQueryClient {
+
+  @PostMapping("")
+  List<Map<String, Object>> getContentsPrivileged(@RequestBody ContentsRequest contentsRequest);
+}

--- a/src/test/java/org/folio/list/rest/SystemUserClientTest.java
+++ b/src/test/java/org/folio/list/rest/SystemUserClientTest.java
@@ -1,0 +1,179 @@
+package org.folio.list.rest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import feign.Request;
+import feign.Response;
+import feign.okhttp.OkHttpClient;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.model.SystemUser;
+import org.folio.spring.model.UserToken;
+import org.folio.spring.service.SystemUserService;
+import org.folio.spring.testing.type.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@UnitTest
+class SystemUserClientTest {
+
+  private SystemUserService systemUserService;
+  private FolioExecutionContext executionContext;
+  private SystemUserClient systemUserClient;
+  private OkHttpClient okHttpClient;
+
+  @BeforeEach
+  void setup() {
+    executionContext = mock(FolioExecutionContext.class);
+    systemUserService = mock(SystemUserService.class);
+    okHttpClient = mock(OkHttpClient.class);
+    systemUserClient = new SystemUserClient(executionContext, systemUserService, null);
+    ReflectionTestUtils.setField(systemUserClient, "delegate", okHttpClient);
+  }
+
+  static List<Arguments> urlPreparationCases() {
+    return List.of(
+      arguments("http://test-url", null, "http://test-url"),
+      arguments("http://test-url", "http://okapi", "http://okapi/test-url"),
+      arguments("http://test-url", "http://okapi/", "http://okapi/test-url")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("urlPreparationCases")
+  void testUrlPreparation(String requestUrl, String okapiUrl, String expected) {
+    when(executionContext.getOkapiUrl()).thenReturn(okapiUrl);
+    assertThat(SystemUserClient.prepareUrl(requestUrl, executionContext), is(expected));
+  }
+
+  @Test
+  void testHeaderPreparationWithNoLanguage() {
+    String tenantId = "tenant_01";
+    Request request = mock(Request.class);
+    when(request.headers())
+      .thenReturn(
+        Map.of(
+          "a", List.of("a-val"),
+          "b", List.of("b-val"),
+          "c", List.of("c-val")
+        )
+      );
+
+    when(executionContext.getOkapiHeaders()).thenReturn(Map.of("z", List.of("z-val"), "x-okapi-tenant", List.of(tenantId)));
+    when(executionContext.getAllHeaders()).thenReturn(Map.of("misc-1", List.of("misc-1-val"), "misc-2", List.of("misc-2-val")));
+    when(systemUserService.getAuthedSystemUser(tenantId)).thenReturn(new SystemUser("", "", "", new UserToken("accessToken", null), ""));
+
+    assertThat(
+      systemUserClient.prepareHeaders(request, executionContext),
+      is(
+        allOf(
+          hasEntry("a", List.of("a-val")),
+          hasEntry("b", List.of("b-val")),
+          hasEntry("c", List.of("c-val")),
+          hasEntry("z", List.of("z-val")),
+          hasEntry("x-okapi-tenant", List.of("tenant_01")),
+          hasEntry("x-okapi-token", List.of("accessToken")),
+          is(aMapWithSize(6))
+        )
+      )
+    );
+  }
+
+  @Test
+  void testHeaderPreparationWithLanguage() {
+    Request request = mock(Request.class);
+    when(request.headers())
+      .thenReturn(
+        Map.of(
+          "a", List.of("a-val"),
+          "b", List.of("b-val"),
+          "c", List.of("c-val")
+        )
+      );
+
+    when(executionContext.getOkapiHeaders()).thenReturn(Map.of("z", List.of("z-val")));
+    when(executionContext.getAllHeaders())
+      .thenReturn(
+        Map.of(
+          "misc-1", List.of("misc-1-val"),
+          "accept-language", List.of("en-US,en;q=0.9"),
+          "misc-2", List.of("misc-2-val")
+        )
+      );
+
+    assertThat(
+      systemUserClient.prepareHeaders(request, executionContext),
+      is(
+        allOf(
+          hasEntry("a", List.of("a-val")),
+          hasEntry("b", List.of("b-val")),
+          hasEntry("c", List.of("c-val")),
+          hasEntry("z", List.of("z-val")),
+          hasEntry("Accept-Language", List.of("en-US,en;q=0.9")),
+          is(aMapWithSize(5))
+        )
+      )
+    );
+  }
+
+  @Test
+  void testRequestExecution() throws IOException {
+    final Request request = Request.create(
+      Request.HttpMethod.GET,
+      "http://test-url",
+      Map.of("a", List.of("a-val")),
+      Request.Body.create("test-data"),
+      null
+    );
+
+    final Request.Options options = new Request.Options();
+    when(executionContext.getOkapiUrl()).thenReturn("http://okapi");
+    when(executionContext.getOkapiHeaders()).thenReturn(Map.of("z", List.of("z-val")));
+    when(executionContext.getAllHeaders())
+      .thenReturn(
+        Map.of(
+          "misc-1", List.of("misc-1-val"),
+          "accept-language", List.of("en-US,en;q=0.9"),
+          "misc-2", List.of("misc-2-val")
+        )
+      );
+    when(okHttpClient.execute(any(Request.class), eq(options)))
+      .thenReturn(Response.builder().request(request).status(299).build());
+
+    assertThat(systemUserClient.execute(request, options).status(), is(299));
+    ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+    verify(okHttpClient, times(1)).execute(requestCaptor.capture(), eq(options));
+
+    assertThat(requestCaptor.getValue().httpMethod(), is(Request.HttpMethod.GET));
+    assertThat(requestCaptor.getValue().url(), is("http://okapi/test-url"));
+    assertThat(
+      requestCaptor.getValue().headers(),
+      is(
+        allOf(
+          hasEntry("a", List.of("a-val")),
+          hasEntry("z", List.of("z-val")),
+          hasEntry("Accept-Language", List.of("en-US,en;q=0.9")),
+          is(aMapWithSize(3))
+        )
+      )
+    );
+  }
+}

--- a/src/test/java/org/folio/list/service/export/CsvCreatorTest.java
+++ b/src/test/java/org/folio/list/service/export/CsvCreatorTest.java
@@ -8,7 +8,7 @@ import org.folio.list.domain.ListEntity;
 import org.folio.list.repository.ListContentsRepository;
 import org.folio.list.repository.ListExportRepository;
 import org.folio.list.rest.EntityTypeClient;
-import org.folio.list.rest.QueryClient;
+import org.folio.list.rest.SystemUserQueryClient;
 import org.folio.list.services.ListActions;
 import org.folio.list.services.export.CsvCreator;
 import org.folio.list.services.export.ExportLocalStorage;
@@ -18,6 +18,7 @@ import org.folio.querytool.domain.dto.EntityType;
 import org.folio.querytool.domain.dto.EntityTypeColumn;
 import org.folio.querytool.domain.dto.StringType;
 import org.folio.s3.client.FolioS3Client;
+import org.folio.s3.exception.S3ClientException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -32,8 +33,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -43,7 +47,7 @@ class CsvCreatorTest {
   @Mock
   private EntityTypeClient entityTypeClient;
   @Mock
-  private QueryClient queryClient;
+  private SystemUserQueryClient queryClient;
   @Mock
   private ListExportRepository listExportRepository;
   @Mock(mockMaker = MockMakers.INLINE)
@@ -109,6 +113,27 @@ class CsvCreatorTest {
       assertEquals(toCSV(contentsWithData), actualCsv);
       assertEquals(2, partETags.size());
     }
+  }
+
+  @Test
+  void shouldRetryUploadPartIfExceptionIsThrown() {
+    int batchSize = 100000;
+    UUID userId = UUID.randomUUID();
+    String destinationFileName = "destinationFileName";
+    String uploadId = "uploadId";
+    var partETags = new ArrayList<String>();
+    int firstPartNumber = 1;
+
+    ListEntity entity = TestDataFixture.getPrivateListEntity();
+    EntityType entityType = createEntityType(List.of(createColumn("id"), createColumn("item_status")));
+    ExportDetails exportDetails = createExportDetails(entity, UUID.randomUUID());
+
+    when(exportProperties.getBatchSize()).thenReturn(batchSize);
+    when(entityTypeClient.getEntityType(entity.getEntityTypeId(), ListActions.EXPORT)).thenReturn(entityType);
+    when(folioS3Client.uploadMultipartPart(eq(destinationFileName), eq(uploadId), eq(firstPartNumber), any())).thenThrow(S3ClientException.class);
+
+    assertThrows(S3ClientException.class, () -> csvCreator.createAndUploadCSV(exportDetails, destinationFileName, uploadId, partETags, userId));
+    verify(folioS3Client, times(5)).uploadMultipartPart(eq(destinationFileName), eq(uploadId), eq(firstPartNumber), any());
   }
 
   private static String toCSV(List<Map<String, Object>> list) {


### PR DESCRIPTION
## Purpose
[MODLISTS-158](https://folio-org.atlassian.net/browse/MODLISTS-158): Exports fail during S3 upload

Addresses 2 problems with exports:
1. Failures during S3 upload (solved by retrying upload with exponential backoff)
2. Failures due to system user token expiring mid-export (solved by new feign client implementation that re-authenticates system user and updates token)
