### PR TITLE
[MODLISTS-161] Consider daylight savings when determining dates to show for user-friendly queries

### DIFF
--- a/src/main/java/org/folio/list/rest/ConfigurationClient.java
+++ b/src/main/java/org/folio/list/rest/ConfigurationClient.java
@@ -1,12 +1,39 @@
 package org.folio.list.rest;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.FeignException;
+import java.time.DateTimeException;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.GetMapping;
 
+@Log4j2
 @Service
 @FeignClient(name = "configurations")
-public interface ConfigurationClient {
+@RequiredArgsConstructor(onConstructor_ = @Autowired)
+public abstract class ConfigurationClient {
+
+  private final ObjectMapper objectMapper;
+
   @GetMapping("/entries?query=(module==ORG and configName==localeSettings)")
-  String getLocaleSettings();
+  public abstract String getLocaleSettings();
+
+  public ZoneId getTenantTimezone() {
+    try {
+      String localeSettingsResponse = this.getLocaleSettings();
+      JsonNode localeSettingsNode = objectMapper.readTree(localeSettingsResponse);
+      String valueString = localeSettingsNode.path("configs").get(0).path("value").asText();
+      JsonNode valueNode = objectMapper.readTree(valueString);
+      return ZoneId.of(valueNode.path("timezone").asText());
+    } catch (JsonProcessingException | FeignException.Unauthorized | NullPointerException | DateTimeException e) {
+      log.error("Failed to retrieve timezone information from mod-configuration. Defaulting to UTC.", e);
+      return ZoneId.of("UTC");
+    }
+  }
 }

--- a/src/main/java/org/folio/list/rest/ConfigurationClient.java
+++ b/src/main/java/org/folio/list/rest/ConfigurationClient.java
@@ -9,24 +9,24 @@ import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.stereotype.Component;
 
+/**
+ * Convenience methods wrapping {@link ConfigurationClientRaw}.
+ */
+// this must be a separate class as feign clients must be interfaces,
+// disallowing any injection (ObjectMapper) or fields (our logger)
 @Log4j2
-@Service
-@FeignClient(name = "configurations")
+@Component
 @RequiredArgsConstructor(onConstructor_ = @Autowired)
-public abstract class ConfigurationClient {
+public class ConfigurationClient {
 
   private final ObjectMapper objectMapper;
-
-  @GetMapping("/entries?query=(module==ORG and configName==localeSettings)")
-  public abstract String getLocaleSettings();
+  private final ConfigurationClientRaw underlyingClient;
 
   public ZoneId getTenantTimezone() {
     try {
-      String localeSettingsResponse = this.getLocaleSettings();
+      String localeSettingsResponse = underlyingClient.getLocaleSettings();
       JsonNode localeSettingsNode = objectMapper.readTree(localeSettingsResponse);
       String valueString = localeSettingsNode.path("configs").get(0).path("value").asText();
       JsonNode valueNode = objectMapper.readTree(valueString);

--- a/src/main/java/org/folio/list/rest/ConfigurationClientRaw.java
+++ b/src/main/java/org/folio/list/rest/ConfigurationClientRaw.java
@@ -1,0 +1,15 @@
+package org.folio.list.rest;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.GetMapping;
+
+/**
+ * Provides raw access to the mod-configurations API. You probably want {@link ConfigurationClient} instead.
+ */
+@Service
+@FeignClient(name = "configurations")
+public interface ConfigurationClientRaw {
+  @GetMapping("/entries?query=(module==ORG and configName==localeSettings)")
+  public abstract String getLocaleSettings();
+}

--- a/src/test/java/org/folio/list/rest/ConfigurationClientTest.java
+++ b/src/test/java/org/folio/list/rest/ConfigurationClientTest.java
@@ -1,0 +1,83 @@
+package org.folio.list.rest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.FeignException;
+import java.time.ZoneId;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ConfigurationClientTest {
+
+  private static final String UTC_MINUS_THREE_LOCALE =
+    """
+    {
+      "configs": [
+        {
+           "id":"2a132a01-623b-4d3a-9d9a-2feb777665c2",
+           "module":"ORG",
+           "configName":"localeSettings",
+           "enabled":true,
+           "value":"{\\"locale\\":\\"en-US\\",\\"timezone\\":\\"America/Montevideo\\",\\"currency\\":\\"USD\\"}","metadata":{"createdDate":"2024-03-25T17:37:22.309+00:00","createdByUserId":"db760bf8-e05a-4a5d-a4c3-8d49dc0d4e48"}
+        }
+      ],
+      "totalRecords": 1,
+      "resultInfo": {"totalRecords":1,"facets":[],"diagnostics":[]}
+    }
+    """;
+
+  private static final String EMPTY_LOCALE_JSON =
+    """
+    {
+      "configs": [],
+      "totalRecords": 0,
+      "resultInfo": {"totalRecords":1,"facets":[],"diagnostics":[]}
+    }
+    """;
+
+  @Spy
+  private ConfigurationClient configurationClient = spy(new ConfigurationClientImpl());
+
+  // the feign client is abstract, however, has an autowired field, so Mockito cannot create a spy automatically
+  private class ConfigurationClientImpl extends ConfigurationClient {
+
+    public ConfigurationClientImpl() {
+      super(new ObjectMapper());
+    }
+
+    @Override
+    public String getLocaleSettings() {
+      return null;
+    }
+  }
+
+  @Test
+  void testTenantTimezoneWhenPresent() {
+    when(configurationClient.getLocaleSettings()).thenReturn(UTC_MINUS_THREE_LOCALE);
+
+    assertThat(configurationClient.getTenantTimezone(), is(ZoneId.of("America/Montevideo")));
+  }
+
+  @Test
+  void testTenantTimezoneWhenNonePresent() {
+    when(configurationClient.getLocaleSettings()).thenReturn(EMPTY_LOCALE_JSON);
+
+    assertThat(configurationClient.getTenantTimezone(), is(ZoneId.of("UTC")));
+  }
+
+  @Test
+  void testHandlesException() {
+    when(configurationClient.getLocaleSettings())
+      .thenThrow(new FeignException.Unauthorized("", mock(feign.Request.class), null, null));
+
+    assertThat(configurationClient.getTenantTimezone(), is(ZoneId.of("UTC")));
+  }
+}

--- a/src/test/java/org/folio/list/rest/ConfigurationClientTest.java
+++ b/src/test/java/org/folio/list/rest/ConfigurationClientTest.java
@@ -5,12 +5,14 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.FeignException;
 import java.time.ZoneId;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -47,6 +49,9 @@ class ConfigurationClientTest {
 
   @Mock
   private ConfigurationClientRaw underlyingClient;
+
+  @Spy // lazy way to make it inject into ConfigurationClient
+  private ObjectMapper objectMapper = new ObjectMapper();
 
   @Test
   void testTenantTimezoneWhenPresent() {


### PR DESCRIPTION
## Why did this happen?

The frontend uses the date being analyzed to get the offset (4 or 5 as applicable):
- midnight Oct 1 New York time is in UTC-4, so it gets `2024-10-01T04:00:00Z`
- midnight Dec 1 New York time is in UTC-5, so it gets `2024-12-01T05:00:00Z`

However, the backend was using the current date to determine the UTC offset, which resulted in either four or five hours, depending on the date that the server handled the request.

We didn't see this before (during DST) as we calculated an offset of 5, so when truncated to just the date it looked correct.

