### PR TITLE
MODLISTS-160 Add a missing interface to the MD

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -187,16 +187,16 @@
   ],
   "requires": [
     {
-      "id": "fqm-query",
-      "version": "2.1"
+      "id": "configuration",
+      "version": "2.0"
     },
     {
-      "id": "entity-types",
+    "id": "entity-types",
       "version": "1.0 2.0"
     },
     {
-      "id": "users",
-      "version": "16.0"
+      "id": "fqm-query",
+      "version": "2.1"
     },
     {
       "id": "login",
@@ -205,6 +205,10 @@
     {
       "id": "permissions",
       "version": "5.3"
+    },
+    {
+      "id": "users",
+      "version": "16.0"
     }
   ],
   "metadata": {


### PR DESCRIPTION
This commit adds the "configuration" interface to the "requires" section of the module descriptor. This commit also rearranges that section, sorting it alphabetically.