### PR TITLE
MODLISTS-165: Use custom SystemUserClient only when system user is enabled

### DIFF
--- a/src/main/java/org/folio/list/configuration/SystemUserFeignConfig.java
+++ b/src/main/java/org/folio/list/configuration/SystemUserFeignConfig.java
@@ -4,14 +4,24 @@ import feign.Client;
 import okhttp3.OkHttpClient;
 import org.folio.list.rest.SystemUserClient;
 import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.client.EnrichUrlAndHeadersClient;
 import org.folio.spring.service.SystemUserService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
 public class SystemUserFeignConfig {
 
   @Bean
-  public Client feignClient(FolioExecutionContext executionContext, SystemUserService systemUserService) {
+  @ConditionalOnBean(SystemUserService.class)
+  public Client systemUserFeignClient(FolioExecutionContext executionContext, SystemUserService systemUserService) {
     return new SystemUserClient(executionContext, systemUserService, new OkHttpClient());
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(SystemUserService.class)
+  public Client defaultFeignClient(FolioExecutionContext executionContext) {
+    return new EnrichUrlAndHeadersClient(executionContext, new OkHttpClient());
   }
 }
 


### PR DESCRIPTION
## Purpose
[MODLISTS-165](https://folio-org.atlassian.net/browse/MODLISTS-165): Use custom SystemUserClient only when system user is enabled
