### PR TITLE
MODLISTS-175 Include hidden fields in UFQ generation

### DIFF
--- a/src/main/java/org/folio/list/rest/EntityTypeClient.java
+++ b/src/main/java/org/folio/list/rest/EntityTypeClient.java
@@ -21,16 +21,24 @@ public interface EntityTypeClient {
   @GetMapping("/{entityTypeId}")
   EntityType getEntityType(@RequestHeader UUID entityTypeId);
 
+  @GetMapping("/{entityTypeId}")
+  EntityType getEntityType(@RequestHeader UUID entityTypeId, @RequestParam boolean includeHidden);
+
   /** Gets an entity type; includes wrappers for feign exceptions */
-  default EntityType getEntityType(UUID entityTypeId, ListActions attemptedAction) {
+  default EntityType getEntityType(UUID entityTypeId, ListActions attemptedAction, boolean includeHidden) {
     try {
-      return getEntityType(entityTypeId);
+      return getEntityType(entityTypeId, includeHidden);
     } catch (FeignException.Unauthorized e) {
       String message = e.getMessage();
       throw new InsufficientEntityTypePermissionsException(entityTypeId, attemptedAction, message);
     } catch (FeignException.NotFound e) {
       throw new NotFoundException("Entity type with id " + entityTypeId + " was not found.");
     }
+  }
+  
+  /** Gets an entity type; includes wrappers for feign exceptions */
+  default EntityType getEntityType(UUID entityTypeId, ListActions attemptedAction) {
+    return getEntityType(entityTypeId, attemptedAction, false);
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/folio/list/services/UserFriendlyQueryService.java
+++ b/src/main/java/org/folio/list/services/UserFriendlyQueryService.java
@@ -78,7 +78,7 @@ public class UserFriendlyQueryService {
 
   public void updateListUserFriendlyQuery(ListEntity listEntity) {
     listEntity.setUserFriendlyQuery(
-      getUserFriendlyQuery(listEntity.getFqlQuery(), entityTypeClient.getEntityType(listEntity.getEntityTypeId(), ListActions.UPDATE))
+      getUserFriendlyQuery(listEntity.getFqlQuery(), entityTypeClient.getEntityType(listEntity.getEntityTypeId(), ListActions.UPDATE, true))
     );
   }
 

--- a/src/test/java/org/folio/list/rest/EntityTypeClientTest.java
+++ b/src/test/java/org/folio/list/rest/EntityTypeClientTest.java
@@ -3,6 +3,8 @@ package org.folio.list.rest;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -29,14 +31,14 @@ class EntityTypeClientTest {
 
   @Test
   void testReturnsOnSuccess() {
-    when(entityTypeClient.getEntityType(ENTITY_TYPE_ID)).thenReturn(ENTITY_TYPE);
+    when(entityTypeClient.getEntityType(ENTITY_TYPE_ID, false)).thenReturn(ENTITY_TYPE);
 
-    assertThat(entityTypeClient.getEntityType(ENTITY_TYPE_ID, ListActions.READ), is(ENTITY_TYPE));
+    assertThat(entityTypeClient.getEntityType(ENTITY_TYPE_ID, ListActions.READ, false), is(ENTITY_TYPE));
   }
 
   @Test
   void testHandlesUnauthorized() {
-    when(entityTypeClient.getEntityType(ENTITY_TYPE_ID))
+    when(entityTypeClient.getEntityType(ENTITY_TYPE_ID, false))
       .thenThrow(
         new FeignException.Unauthorized(
           "[{\"User is missing permissions: [foo.bar]\"}]",
@@ -48,15 +50,15 @@ class EntityTypeClientTest {
 
     assertThrows(
       InsufficientEntityTypePermissionsException.class,
-      () -> entityTypeClient.getEntityType(ENTITY_TYPE_ID, ListActions.READ)
+      () -> entityTypeClient.getEntityType(ENTITY_TYPE_ID, ListActions.READ, false)
     );
   }
 
   @Test
   void testHandlesNotFound() {
-    when(entityTypeClient.getEntityType(ENTITY_TYPE_ID))
+    when(entityTypeClient.getEntityType(ENTITY_TYPE_ID, false))
       .thenThrow(new FeignException.NotFound("Entity type not found", mock(feign.Request.class), null, null));
 
-    assertThrows(NotFoundException.class, () -> entityTypeClient.getEntityType(ENTITY_TYPE_ID, ListActions.READ));
+    assertThrows(NotFoundException.class, () -> entityTypeClient.getEntityType(ENTITY_TYPE_ID, ListActions.READ, false));
   }
 }

--- a/src/test/java/org/folio/list/service/UserFriendlyQueryServiceTest.java
+++ b/src/test/java/org/folio/list/service/UserFriendlyQueryServiceTest.java
@@ -117,7 +117,7 @@ class UserFriendlyQueryServiceTest {
     );
 
     when(fqlService.getFql("query")).thenReturn(new Fql("", equalsCondition));
-    when(entityTypeClient.getEntityType(testList.getEntityTypeId(), ListActions.UPDATE)).thenReturn(new EntityType().columns(columns));
+    when(entityTypeClient.getEntityType(testList.getEntityTypeId(), ListActions.UPDATE, true)).thenReturn(new EntityType().columns(columns));
 
     userFriendlyQueryService.updateListUserFriendlyQuery(testList);
     assertEquals(expectedEqualsCondition, testList.getUserFriendlyQuery());


### PR DESCRIPTION
This commit updates our approach to generating user-friendly queries, so that it includes hidden fields in the entity types it uses to look up things like field metadata