### PR TITLE
Add consortia permission to mod-lists system user

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -211,6 +211,12 @@
       "version": "16.0"
     }
   ],
+  "optional": [
+    {
+      "id": "consortia",
+      "version": "1.0"
+    }
+  ],
   "metadata": {
     "user": {
       "type": "system",
@@ -220,6 +226,7 @@
         "circulation-storage.loan-policies.collection.get",
         "circulation.loans.collection.get",
         "configuration.entries.collection.get",
+        "consortia.user-tenants.collection.get",
         "departments.collection.get",
         "finance.exchange-rate.item.get",
         "fqm.entityTypes.collection.get",

--- a/src/main/resources/system-user-permissions.txt
+++ b/src/main/resources/system-user-permissions.txt
@@ -2,6 +2,7 @@ acquisitions-units.units.collection.get
 addresstypes.collection.get
 circulation-storage.loan-policies.collection.get
 circulation.loans.collection.get
+consortia.user-tenants.collection.get
 configuration.entries.collection.get
 departments.collection.get
 finance.exchange-rate.item.get


### PR DESCRIPTION
## Purpose
Address permission issue from https://folio-org.atlassian.net/browse/BF-961 

Permissions are kind of a mess:
  1. Long-running exports were failing in okapi environments due to the system user token expiring. We implemented a workaround where, in okapi environments, we re-authenticate the system user during every call to mod-fqm-manager during exports. This resolved the problem of long-running exports failing. However, now:
  2. Since the system user gets re-authenticated during each call, the old token (which would theoretically contain any module permissions needed by the mod-fqm-manager API call) gets replaced. Meaning that we no longer have the module permissions for the call.
  3. So we need to re-authenticate the system user, but also need to make sure we keep the module permission `consortia.user-tenants.collection.get`. So I think we basically need this to be a system user permission.

Potential problem: if `consortia` is optional, then it might cause problems trying to assign the permission to the system user.
