### PR TITLE
MODLISTS-178 Make migration errors non-fatal

### DIFF
--- a/src/main/java/org/folio/list/services/CustomTenantService.java
+++ b/src/main/java/org/folio/list/services/CustomTenantService.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.util.concurrent.CompletionException;
 
 @Log4j2
 @Primary

--- a/src/main/java/org/folio/list/services/MigrationService.java
+++ b/src/main/java/org/folio/list/services/MigrationService.java
@@ -85,7 +85,11 @@ public class MigrationService {
             systemUserScopedExecutionService.executeSystemUserScoped(
               tenant,
               () -> {
-                migrateList(list);
+                try {
+                  migrateList(list);
+                } catch (Exception e) {
+                  log.error("Error migrating list {}. This list may not function correctly", list, e);
+                }
                 return null;
               }
             )


### PR DESCRIPTION
This commit makes it so the list migration service will catch and log errors that happen when migrating lists, as we don't want edge cases and invalid lists to break the whole module or break the installation process
