### PR TITLE
Require entity-types interface v2.0

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -192,7 +192,7 @@
     },
     {
     "id": "entity-types",
-      "version": "1.0 2.0"
+      "version": "2.0"
     },
     {
       "id": "fqm-query",


### PR DESCRIPTION
This should have been done initially, as the response processing expects the new `/entity-types` structure that includes the `_version` field