### PR TITLE
[MODFQMMGR-522] Set thread pool core size to 9

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -73,7 +73,7 @@ spring:
   task:
     execution:
       pool:
-        core-size: 10
+        core-size: 9
         max-size: 10 # Max number of concurrent async tasks
         queue-capacity: 1000
       thread-name-prefix: mod-lists-task-


### PR DESCRIPTION
## Purpose
[MODFQMMGR-522](https://folio-org.atlassian.net/browse/MODFQMMGR-522)

Mod-lists had a core thread pool size of 10, while mod-fqm-manager's was 9. This was leading to some nasty behavior when 10+ simultaneous refreshes were run. While the modules should be able to handle this situation better, the quick and easy fix is just to make sure their thread pools are the same size. Tested with varying amounts of refreshes (10-25) and didn't see any failures after this change.

This issue should still be investigated more, since the modules should be able to function correctly even with different thread pool sizes. But the fact that:
  1. This functionally fixes the problem
  2. The problem only occurred in the first place if there were 10+ simultaneous refreshes, which is a very unlikely scenario

makes me think that this "band-aid" solution should be sufficient for now. For future investigation, I created this ticket: https://folio-org.atlassian.net/browse/MODLISTS-182 
