### PR TITLE
MODLISTS-187: Spring Boot 3.3.7, folio-s3-client 2.2.1, aws s3 2.29.47

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.3</version>
+    <version>3.3.7</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>org.folio</groupId>
@@ -29,11 +29,10 @@
     <mapstruct.version>1.6.2</mapstruct.version>
     <lib-fqm-query-processor.version>3.0.1</lib-fqm-query-processor.version>
     <jackson-dataformat-csv.version>2.14.2</jackson-dataformat-csv.version>
-    <aws-sdk-java.version>2.19.2</aws-sdk-java.version>
-    <folio-s3-client.version>2.1.0</folio-s3-client.version>
+    <aws-sdk-java.version>2.29.47</aws-sdk-java.version>
+    <folio-s3-client.version>2.2.1</folio-s3-client.version>
     <awaitility.version>4.2.0</awaitility.version>
     <snakeyaml.version>2.0</snakeyaml.version>
-    <snappy-java.version>1.1.10.5</snappy-java.version>
     <spring-retry.version>2.0.10</spring-retry.version>
 
     <!-- test dependencies -->
@@ -185,15 +184,9 @@
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
-      <artifactId>aws-sdk-java</artifactId>
+      <artifactId>s3</artifactId>
       <version>${aws-sdk-java.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.xerial.snappy</groupId>
-      <artifactId>snappy-java</artifactId>
-      <version>${snappy-java.version}</version>
-    </dependency>
-
 
     <!-- Test dependencies -->
     <dependency>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODLISTS-187

## Purpose
Fix security vulnerabilities in Spring Boot and S3 dependencies.

## Approach
Upgrade Spring Boot from 3.2.3 to 3.3.7.

Note that OSS support for Spring Boot 3.2.x has ended 2024-11-23: https://spring.io/projects/spring-boot#support

Note that Ramsons requires Spring Boot 3.3.x: https://folio-org.atlassian.net/wiki/spaces/TC/pages/5058042/Ramsons#Ramsons-ThirdPartyLibraries/Frameworks

Upgrade folio-s3-client from 2.1.0 to 2.2.1.

Upgrade aws s3 client from 2.19.2 to 2.29.47.

folio-s3-client.version 2.2.1 only needs aws s3, not the complete aws-sdk-java: https://github.com/folio-org/folio-s3-client/blob/v2.2.1/pom.xml#L62-L65

folio-s3-client.version 2.2.1 ships with snappy-java 1.1.10.7, no need to downgrade snappy-java.

The aws s3 client upgrade indirectly upgrades netty-codec-http from 4.1.107.Final to 4.1.116.Final fixing

* https://www.cve.org/CVERecord?id=CVE-2024-29025 Allocation of Resources Without Limits or Throttling

The folio-s3-client upgrade indirectly upgrades bcprov-jdk18on from 1.76 to 1.78.1 fixing

* https://www.cve.org/CVERecord?id=CVE-2024-30172 Infinite loop in ED25519 verification
* https://www.cve.org/CVERecord?id=CVE-2024-29857 Excessive CPU consumption in ECCurve certificate verification

The Spring Boot upgrade indirectly upgrades tomcat-embed-core from 10.1.19 to 10.1.34 fixing

* https://www.cve.org/CVERecord?id=CVE-2024-38286 OutOfMemoryError in TLS 1.3 handshake
* https://www.cve.org/CVERecord?id=CVE-2024-34750 Insufficient Session Expiration

## Learning
Before releasing a module for a new flower release upgrade the dependencies.
