### PR TITLE
[MODLISTS-188] Stream export downloads directly without buffering

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # 3.0.x
+- Stream export downloads directly without buffering ([MODLISTS-186](https://folio-org.atlassian.net/browse/MODLISTS-186))
 
 ## 3.0.7
 - Add instance-format permission to mod-lists system user

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,13 @@
       <artifactId>jackson-core</artifactId>
     </dependency>
 
+
+    <!-- for system user caching -->
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+      <version>3.1.8</version>
+    </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,14 +63,13 @@
 
   <dependencies>
     <dependency>
-        <groupId>com.github.folio-org.folio-spring-support</groupId>
-        <artifactId>folio-spring-system-user</artifactId>
-        <version>folsprings-183-for-test-SNAPSHOT</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-spring-base</artifactId>
+      <version>${folio-spring-base.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-spring-system-user</artifactId>
       <version>${folio-spring-base.version}</version>
     </dependency>
     <dependency>
@@ -112,13 +111,13 @@
       <artifactId>jackson-core</artifactId>
     </dependency>
 
-
     <!-- for system user caching -->
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
       <version>3.1.8</version>
     </dependency>
+
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
@@ -423,16 +422,11 @@
   </build>
 
   <repositories>
-
     <repository>
       <id>folio-nexus</id>
       <name>FOLIO Maven repository</name>
       <url>https://repository.folio.org/repository/maven-folio</url>
     </repository>
-		<repository>
-		    <id>jitpack.io</id>
-		    <url>https://www.jitpack.io</url>
-		</repository>
   </repositories>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -63,20 +63,11 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.folio</groupId>
-      <artifactId>folio-spring-base</artifactId>
-      <version>${folio-spring-base.version}</version>
+        <groupId>com.github.folio-org</groupId>
+        <artifactId>folio-spring-support</artifactId>
+        <version>folsprings-183-for-test-SNAPSHOT</version>
     </dependency>
-    <dependency>
-      <groupId>org.folio</groupId>
-      <artifactId>folio-spring-system-user</artifactId>
-      <version>${folio-spring-base.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.folio</groupId>
-      <artifactId>folio-spring-i18n</artifactId>
-      <version>${folio-spring-base.version}</version>
-    </dependency>
+
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>lib-fqm-query-processor</artifactId>
@@ -414,11 +405,16 @@
   </build>
 
   <repositories>
+
     <repository>
       <id>folio-nexus</id>
       <name>FOLIO Maven repository</name>
       <url>https://repository.folio.org/repository/maven-folio</url>
     </repository>
+		<repository>
+		    <id>jitpack.io</id>
+		    <url>https://www.jitpack.io</url>
+		</repository>
   </repositories>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -63,9 +63,20 @@
 
   <dependencies>
     <dependency>
-        <groupId>com.github.folio-org</groupId>
-        <artifactId>folio-spring-support</artifactId>
+        <groupId>com.github.folio-org.folio-spring-support</groupId>
+        <artifactId>folio-spring-system-user</artifactId>
         <version>folsprings-183-for-test-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-spring-base</artifactId>
+      <version>${folio-spring-base.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-spring-i18n</artifactId>
+      <version>${folio-spring-base.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/folio/list/controller/ListExportController.java
+++ b/src/main/java/org/folio/list/controller/ListExportController.java
@@ -1,17 +1,16 @@
 package org.folio.list.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.tuple.Pair;
 import org.folio.list.domain.dto.ListExportDTO;
 import org.folio.list.rest.resource.ListExportApi;
 import org.folio.list.services.export.ListExportService;
+import org.folio.list.services.export.ListExportService.ExportDownloadContents;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
@@ -39,15 +38,16 @@ public class ListExportController implements ListExportApi {
 
   @Override
   public ResponseEntity<Resource> downloadList(UUID id, UUID exportId) {
-    Pair<String, InputStream> listNameAndCsvPair = listExportService.downloadExport(id, exportId);
-    var resource = new InputStreamResource(listNameAndCsvPair.getRight());
-    String fileName = listNameAndCsvPair.getLeft() + ".csv";
-    var headers = new HttpHeaders();
+    ExportDownloadContents download = listExportService.downloadExport(id, exportId);
+    String fileName = download.listName() + ".csv";
+
+    HttpHeaders headers = new HttpHeaders();
     headers.setContentDisposition(ContentDisposition.builder("attachment").filename(fileName, StandardCharsets.UTF_8).build());
     return ResponseEntity.ok()
       .headers(headers)
       .contentType(MediaType.valueOf(TEXT_CSV))
-      .body(resource);
+      .contentLength(download.length())
+      .body(new InputStreamResource(download.stream()));
   }
 
   @Override


### PR DESCRIPTION
Turns out, sending a resource/stream to Spring directly with no `Content-Length` will cause the entire stream to be read so the content length can be determined. There is no point to this (especially since Okapi strips the `Content-Length` header!!), but we're now avoiding the massive overhead that occurs with all that stream reading.

Additionally, as an extra speedup in the export process, I added `caffeine`, which allows the system user library to use its internal cache and prevent constantly re-authenticating for each export batch.