### PR TITLE
Bump folio-spring-support to 8.3.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
   <properties>
     <!-- runtime dependencies -->
-    <folio-spring-base.version>8.3.0-SNAPSHOT</folio-spring-base.version>
+    <folio-spring-base.version>9.0.0-SNAPSHOT</folio-spring-base.version>
     <commons-collections4.version>4.4</commons-collections4.version>
     <folio-service-tools.version>3.1.0</folio-service-tools.version>
     <mapstruct.version>1.6.2</mapstruct.version>


### PR DESCRIPTION
# ⚠️  Marking as draft due to the following error on refresh/export:

`Row was updated or deleted by another transaction (or unsaved-value mapping was incorrect).`