### PR TITLE
Add general FeignException for retry logic

### DIFF
--- a/src/main/java/org/folio/list/services/CustomTenantService.java
+++ b/src/main/java/org/folio/list/services/CustomTenantService.java
@@ -63,10 +63,13 @@ public class CustomTenantService extends TenantService {
         } catch (Exception e) {
           // Deal with wrapped permission exceptions by unwrapping and rethrowing the original exception.
           log.error("Exception during tenant install migration (attempt # {} )", attempt, e);
-          if (e.getCause() instanceof InsufficientEntityTypePermissionsException ietpe)
+          if (e.getCause() instanceof InsufficientEntityTypePermissionsException ietpe) {
+            log.info("Make retry of InsufficientEntityTypePermissionsException with message: {}", ietpe.getMessage());
             throw ietpe; // Retry
-          if (e.getCause() instanceof FeignException fe)
+          } if (e.getCause() instanceof FeignException fe) {
+            log.info("Make retry of FeignException with message: {}", fe.getMessage());
             throw fe; // Retry
+          }
           throw e; // Don't retry
         }
         return null;

--- a/src/main/java/org/folio/list/services/CustomTenantService.java
+++ b/src/main/java/org/folio/list/services/CustomTenantService.java
@@ -66,7 +66,7 @@ public class CustomTenantService extends TenantService {
           if (e.getCause() instanceof InsufficientEntityTypePermissionsException ietpe) {
             log.info("Make retry of InsufficientEntityTypePermissionsException with message: {}", ietpe.getMessage());
             throw ietpe; // Retry
-          } if (e.getCause() instanceof FeignException fe) {
+          } else if (e.getCause() instanceof FeignException fe) {
             log.info("Make retry of FeignException with message: {}", fe.getMessage());
             throw fe; // Retry
           }

--- a/src/main/java/org/folio/list/services/CustomTenantService.java
+++ b/src/main/java/org/folio/list/services/CustomTenantService.java
@@ -49,7 +49,7 @@ public class CustomTenantService extends TenantService {
 
     // In Eureka, the system user often takes a short bit of time for its permissions to be assigned, so retry in the
     // case of failures related to missing permissions or general Feign exceptions
-    // for cases when mod-roles-keycloak could not retrieve roles for the system user that is not yet created.
+    // for cases in which mod-fqm tries to invoke mod-roles-keycloak and cannot retrieve roles for a system user that has not yet been created.
     RetryTemplate.builder()
       .retryOn(List.of(InsufficientEntityTypePermissionsException.class, FeignException.class))
       .exponentialBackoff(Duration.of(2, ChronoUnit.SECONDS), 1.5, Duration.of(1, ChronoUnit.MINUTES))

--- a/src/main/java/org/folio/list/services/CustomTenantService.java
+++ b/src/main/java/org/folio/list/services/CustomTenantService.java
@@ -65,6 +65,8 @@ public class CustomTenantService extends TenantService {
           log.error("Exception during tenant install migration (attempt #" + attempt + ")", e);
           if (e.getCause() instanceof InsufficientEntityTypePermissionsException ietpe)
             throw ietpe; // Retry
+          if (e.getCause() instanceof FeignException fe)
+            throw fe; // Retry
           throw e; // Don't retry
         }
         return null;

--- a/src/main/java/org/folio/list/services/CustomTenantService.java
+++ b/src/main/java/org/folio/list/services/CustomTenantService.java
@@ -62,7 +62,7 @@ public class CustomTenantService extends TenantService {
           migrationService.performTenantInstallMigrations();
         } catch (Exception e) {
           // Deal with wrapped permission exceptions by unwrapping and rethrowing the original exception.
-          log.error("Exception during tenant install migration (attempt #" + attempt + ")", e);
+          log.error("Exception during tenant install migration (attempt # {} )", attempt, e);
           if (e.getCause() instanceof InsufficientEntityTypePermissionsException ietpe)
             throw ietpe; // Retry
           if (e.getCause() instanceof FeignException fe)

--- a/src/test/java/org/folio/list/service/CustomTenantServiceTest.java
+++ b/src/test/java/org/folio/list/service/CustomTenantServiceTest.java
@@ -7,6 +7,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
@@ -65,7 +66,7 @@ class CustomTenantServiceTest {
         if (Instant.now().isAfter(finishTime)) {
           return null;
         }
-        throw exception;
+        throw new CompletionException(exception);
       })
       .when(migrationService)
       .performTenantInstallMigrations();

--- a/src/test/java/org/folio/list/service/CustomTenantServiceTest.java
+++ b/src/test/java/org/folio/list/service/CustomTenantServiceTest.java
@@ -5,8 +5,14 @@ import static org.mockito.Mockito.*;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import feign.FeignException;
+import feign.Request;
+import feign.Response;
 import org.folio.list.exception.InsufficientEntityTypePermissionsException;
 import org.folio.list.services.CustomTenantService;
 import org.folio.list.services.ListActions;
@@ -16,6 +22,8 @@ import org.folio.tenant.domain.dto.TenantAttributes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -46,8 +54,9 @@ class CustomTenantServiceTest {
     verify(migrationService, times(1)).performTenantInstallMigrations();
   }
 
-  @Test
-  void testMigrationErrorRetry() {
+  @ParameterizedTest
+  @MethodSource("retryExceptionProvider")
+  void testMigrationErrorRetry(Exception exception) {
     // Given a retryable migration error that fails for the first 5 seconds, then succeeds
     Instant finishTime = Instant.now().plus(5, ChronoUnit.SECONDS); // This needs to be greater than the max timeout on the retryTemplate in CustomTenantService
     AtomicInteger attempts = new AtomicInteger(0);
@@ -56,11 +65,7 @@ class CustomTenantServiceTest {
         if (Instant.now().isAfter(finishTime)) {
           return null;
         }
-        throw new InsufficientEntityTypePermissionsException(
-          UUID.randomUUID(),
-          ListActions.UPDATE,
-          "User is missing permissions [{\"missing permission\"]}"
-        );
+        throw exception;
       })
       .when(migrationService)
       .performTenantInstallMigrations();
@@ -72,6 +77,21 @@ class CustomTenantServiceTest {
     // Verify that we didn't get any unexpected calls to the migration service and that it retried at least once
     verify(migrationService, times(attempts.get())).performTenantInstallMigrations();
     assertTrue(attempts.get() > 1, "Expected migration to be retried at least once");
+  }
+
+  static Stream<Exception> retryExceptionProvider() {
+    return Stream.of(
+      new InsufficientEntityTypePermissionsException(
+        UUID.randomUUID(),
+        ListActions.UPDATE,
+        "User is missing permissions [{\"missing permission\"]}"
+      ),
+      FeignException.errorStatus("GET", Response.builder()
+        .status(403)
+        .reason("Forbidden")
+        .request(Request.create(Request.HttpMethod.GET, "", Map.of(), null, null, null))
+        .build())
+    );
   }
 
   @Test


### PR DESCRIPTION
## Purpose
In case when a system user has not been created yet mod-fqm tries to invoke mod-roles-keycloak and fails because of the absence of system user and in this case we have FeignException.
As solution we can add this exception for retry
![image](https://github.com/user-attachments/assets/1bcb65bb-2643-4a8a-b006-b18db4639285)

Note: system user in Eureka started to creating before invoking POST Tenant API

