### PR TITLE
Improve handling of retries by checking all nested causes

### DIFF
--- a/src/test/java/org/folio/list/service/CustomTenantServiceTest.java
+++ b/src/test/java/org/folio/list/service/CustomTenantServiceTest.java
@@ -66,7 +66,7 @@ class CustomTenantServiceTest {
         if (Instant.now().isAfter(finishTime)) {
           return null;
         }
-        throw new CompletionException(exception);
+        throw exception;
       })
       .when(migrationService)
       .performTenantInstallMigrations();
@@ -87,11 +87,24 @@ class CustomTenantServiceTest {
         ListActions.UPDATE,
         "User is missing permissions [{\"missing permission\"]}"
       ),
+      // just exception
       FeignException.errorStatus("GET", Response.builder()
         .status(403)
         .reason("Forbidden")
         .request(Request.create(Request.HttpMethod.GET, "", Map.of(), null, null, null))
-        .build())
+        .build()),
+      // exception with 1 wrapper
+      new CompletionException(FeignException.errorStatus("GET", Response.builder()
+        .status(404)
+        .reason("Not Found")
+        .request(Request.create(Request.HttpMethod.GET, "", Map.of(), null, null, null))
+        .build())),
+      // exception with 2 wrappers
+      new CompletionException(new CompletionException(FeignException.errorStatus("GET", Response.builder()
+        .status(404)
+        .reason("Not Found")
+        .request(Request.create(Request.HttpMethod.GET, "", Map.of(), null, null, null))
+        .build())))
     );
   }
 


### PR DESCRIPTION
## Purpose
In logs we see that FeignException has 2 wrappers before it. 
So need to make more generic logic to handle all possible causes
![image](https://github.com/user-attachments/assets/3f43f30c-dc16-4232-bb90-e3c796875b60)
