### PR TITLE
MODLISTS-211 Remove non-essential fields from canned lists

### DIFF
--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -12,5 +12,6 @@
   <include file="changes/v1.2.0/changelog-v1.2.0.xml" relativeToChangelogFile="true"/>
   <include file="changes/v2.1.0/changelog-v2.1.0.xml" relativeToChangelogFile="true"/>
   <include file="changes/v2.1.1/changelog-v2.1.1.xml" relativeToChangelogFile="true"/>
+  <include file="changes/v2.1.2/changelog-v2.1.2.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v2.1.2/changelog-v2.1.2.xml
+++ b/src/main/resources/db/changelog/changes/v2.1.2/changelog-v2.1.2.xml
@@ -1,0 +1,56 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+  <changeSet id="MODLISTS-211" author="mweaver@ebsco.com" runOnChange="true">
+    <comment>Remove non-essential columns from the canned lists</comment>
+    <sql>
+      INSERT INTO list_details
+      (id, name, description, entity_type_id, fql_query, fields, created_by, created_by_username, created_date, updated_by, updated_by_username, updated_date, is_active, is_private, is_canned, version, user_friendly_query)
+      values
+        ('605a345f-f456-4ab2-8968-22f49cf1fbb6',
+         'Missing items',
+         'Returns all items with a status of: missing, aged to lost, claimed returned, declared lost, long missing',
+         'd0213d22-32cf-490f-9196-d81c3c66e53f',
+         '{"items.status_name": {"$in": ["Missing", "Aged to lost", "Claimed returned", "Declared lost", "Long missing" ] }}',
+         '{items.id, items.hrid, holdings.id, items.effective_call_number, effective_call_number.name, items.status_name, items.copy_number, items.barcode, items.created_date, items.updated_date, effective_location.name, loclibrary.name, loclibrary.code, mtypes.name, instances.id, instances.title, instances.created_at, instances.updated_at, instances.instance_primary_contributor, item_level_call_number.name, permanent_location.name, temporary_location.name}',
+         '7eb41f7c-ec2f-4637-8ceb-2e9573666ad0',
+         'SYSTEM',
+         Now(),
+         '7eb41f7c-ec2f-4637-8ceb-2e9573666ad0',
+         'SYSTEM',
+         Now(),
+         true,
+         false,
+         true,
+         1,
+         'items.status_name in [Missing, Aged to lost, Claimed returned, Declared lost, Long missing]'),
+
+        ('97f5829f-1510-47bc-8454-ae7fa849baef',
+         'Inactive patrons with open loans',
+         'Returns all loans with a status of open by inactive users',
+         'd6729885-f2fb-4dc7-b7d0-a865a7f461e4',
+         '{"$and": [{"loans.status_name" : {"$eq": "Open"}}, {"users.active" : {"$eq": "false"}}]}',
+         '{users.id, users.last_name_first_name, users.active, users.barcode, users.expiration_date, groups.group, loans.id, loans.status_name, loans.due_date, lpolicy.id, lpolicy.name, cospi.name, holdings.id, instance.id, instance.title, instance.instance_primary_contributor, items.id, items.barcode, items.status_name, mtypes.name}',
+         '7eb41f7c-ec2f-4637-8ceb-2e9573666ad0',
+         'SYSTEM',
+         Now(),
+         '7eb41f7c-ec2f-4637-8ceb-2e9573666ad0',
+         'SYSTEM',
+         Now(),
+         true,
+         false,
+         true,
+         1,
+         '(loans.status_name == Open) AND (users.active == false)')
+        ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, description = EXCLUDED.description, entity_type_id = EXCLUDED.entity_type_id,
+                              fql_query = EXCLUDED.fql_query, fields = EXCLUDED.fields, created_by = EXCLUDED.created_by, created_by_username = EXCLUDED.created_by_username,
+                              created_date = EXCLUDED.created_date, updated_by = EXCLUDED.updated_by, updated_by_username = EXCLUDED.updated_by_username,
+                              updated_date = EXCLUDED.updated_date, is_active = EXCLUDED.is_active, is_private = EXCLUDED.is_private, is_canned = EXCLUDED.is_canned,
+                              version = EXCLUDED.version, user_friendly_query = EXCLUDED.user_friendly_query ;
+
+    </sql>
+  </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## Purpose
These fields cause unexpected behavior in the UI when the canned lists are duplicated

## Approach
Remove the offending fields