### PR TITLE
MODFQMMGR-127 - Adding permission for hodlings notes

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -295,7 +295,8 @@
         "voucher.voucher-lines.collection.get",
         "voucher.vouchers.collection.get",
         "waives.collection.get",
-        "inventory-storage.instance-note-types.collection.get"
+        "inventory-storage.instance-note-types.collection.get",
+        "inventory-storage.holdings-note-types.collection.get"
       ]
     }
   },

--- a/src/main/resources/system-user-permissions.txt
+++ b/src/main/resources/system-user-permissions.txt
@@ -72,3 +72,4 @@ voucher.voucher-lines.collection.get
 voucher.vouchers.collection.get
 waives.collection.get
 inventory-storage.instance-note-types.collection.get
+inventory-storage.holdings-note-types.collection.get


### PR DESCRIPTION
## Purpose
Add inventory-storage.holdings-note-types.collection.get permission created in scope of [MODFQMMGR-127](https://folio-org.atlassian.net/browse/MODFQMMGR-127).

## Approach

#### TODOS and Open Questions

## Learning
