### PR TITLE
MODFQMMGR-835 - Adding permission for instance relationships and preceding/succeeding titles

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -296,7 +296,9 @@
         "voucher.vouchers.collection.get",
         "waives.collection.get",
         "inventory-storage.instance-note-types.collection.get",
-        "inventory-storage.holdings-note-types.collection.get"
+        "inventory-storage.holdings-note-types.collection.get",
+        "inventory-storage.instance-relationships.collection.get",
+        "inventory-storage.preceding-succeeding-titles.collection.get"
       ]
     }
   },

--- a/src/main/resources/system-user-permissions.txt
+++ b/src/main/resources/system-user-permissions.txt
@@ -73,3 +73,5 @@ voucher.vouchers.collection.get
 waives.collection.get
 inventory-storage.instance-note-types.collection.get
 inventory-storage.holdings-note-types.collection.get
+inventory-storage.instance-relationships.collection.get
+inventory-storage.preceding-succeeding-titles.collection.get


### PR DESCRIPTION
Add permissions created in scope of [MODFQMMGR-835](https://folio-org.atlassian.net/browse/MODFQMMGR-835)