### PR TITLE
MODLISTS-223 Provide a more useful error when content IDs are invalid

### DIFF
--- a/src/main/java/org/folio/list/domain/ListContent.java
+++ b/src/main/java/org/folio/list/domain/ListContent.java
@@ -12,12 +12,14 @@ import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.With;
 import org.springframework.data.domain.Persistable;
 
 @Data
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
+@With
 @IdClass(ListContentId.class)
 @Table(name = "list_contents")
 // Implements Persistable so that we can explicitly mark each object as new in the DB

--- a/src/main/java/org/folio/list/exception/ListContentsFqmRequestException.java
+++ b/src/main/java/org/folio/list/exception/ListContentsFqmRequestException.java
@@ -1,0 +1,11 @@
+package org.folio.list.exception;
+
+import org.folio.list.domain.ListEntity;
+import org.folio.list.services.ListActions;
+import org.springframework.http.HttpStatus;
+
+public class ListContentsFqmRequestException extends SimpleListException {
+  public ListContentsFqmRequestException(ListEntity list) {
+    super(list, ListActions.READ, "Failed to retrieve list contents for list " + list.getId() + ". This may be due to an upstream data schema change. Please refresh the list.", "list.contents.request.failed", HttpStatus.CONFLICT);
+  }
+}

--- a/src/test/java/org/folio/list/service/ListServiceGetListContentsTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceGetListContentsTest.java
@@ -1,9 +1,11 @@
 package org.folio.list.service;
 
+import feign.FeignException;
 import org.folio.fql.service.FqlService;
 import org.folio.list.domain.ListContent;
 import org.folio.list.domain.ListEntity;
 import org.folio.list.domain.ListRefreshDetails;
+import org.folio.list.exception.ListContentsFqmRequestException;
 import org.folio.list.exception.PrivateListOfAnotherUserException;
 import org.folio.list.repository.ListContentsRepository;
 import org.folio.list.repository.ListRepository;
@@ -32,6 +34,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -62,6 +65,11 @@ class ListServiceGetListContentsTest {
       List.of(UUID.randomUUID().toString()),
       List.of(UUID.randomUUID().toString())
     );
+    List<EntityTypeColumn> columns = List.of(
+      new EntityTypeColumn().name("id").isIdColumn(true).visibleByDefault(true),
+      new EntityTypeColumn().name("something-else").visibleByDefault(false)
+    );
+    EntityType entityType = new EntityType().name("entity-type").columns(columns);
     int offset = 0;
     int size = 2;
     int contentVersion = 2;
@@ -93,6 +101,7 @@ class ListServiceGetListContentsTest {
     when(executionContext.getTenantId()).thenReturn(tenantId);
     when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(expectedEntity));
     when(listContentsRepository.getContents(listId, successRefresh.getId(), new OffsetRequest(offset, size))).thenReturn(listContents);
+    when(entityTypeClient.getEntityType(entityTypeId, ListActions.READ)).thenReturn(entityType);
     when(queryClient.getContents(contentsRequest)).thenReturn(expectedList);
     Optional<ResultsetPage> actualContent = listService.getListContents(listId, fields, offset, size);
     assertThat(actualContent).isEqualTo(expectedContent);
@@ -108,7 +117,7 @@ class ListServiceGetListContentsTest {
       List.of(UUID.randomUUID().toString())
     );
     List<EntityTypeColumn> columns = List.of(
-      new EntityTypeColumn().name("id").visibleByDefault(true),
+      new EntityTypeColumn().name("id").isIdColumn(true).visibleByDefault(true),
       new EntityTypeColumn().name("something-else").visibleByDefault(false)
     );
     EntityType entityType = new EntityType().name("entity-type").columns(columns);
@@ -169,5 +178,197 @@ class ListServiceGetListContentsTest {
     doThrow(new PrivateListOfAnotherUserException(listEntity, ListActions.READ))
       .when(listValidationService).validateRead(listEntity);
     Assertions.assertThrows(PrivateListOfAnotherUserException.class, () -> listService.getListContents(listId, fields, 0, 100));
+  }
+
+  @Test
+  void shouldThrowInvalidListContentsExceptionWhenContentIdSizeMismatch() {
+    String tenantId = "tenant_01";
+    UUID entityTypeId = UUID.randomUUID();
+    UUID listId = UUID.randomUUID();
+
+    // Create content IDs with wrong size (2 IDs instead of expected 1)
+    List<List<String>> contentIds = List.of(
+      List.of(UUID.randomUUID().toString(), UUID.randomUUID().toString())
+    );
+
+    // Entity type expects only 1 ID column
+    List<EntityTypeColumn> columns = List.of(
+      new EntityTypeColumn()
+        .name("id")
+        .isIdColumn(true)
+        .visibleByDefault(true)
+    );
+    EntityType entityType = new EntityType().name("entity-type").columns(columns);
+
+    int offset = 0;
+    int size = 1;
+    int contentVersion = 2;
+    List<String> fields = List.of("id");
+
+    List<ListContent> listContents = contentIds.stream()
+      .map(id -> new ListContent().withContentId(id))
+      .toList();
+
+    ListRefreshDetails successRefresh = ListRefreshDetails.builder().contentVersion(contentVersion).recordsCount(1).build();
+    ListEntity listEntity = new ListEntity()
+      .withSuccessRefresh(successRefresh)
+      .withEntityTypeId(entityTypeId)
+      .withId(listId)
+      .withFields(fields);
+
+    when(executionContext.getTenantId()).thenReturn(tenantId);
+    when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(listEntity));
+    when(listContentsRepository.getContents(listId, successRefresh.getId(), new OffsetRequest(offset, size))).thenReturn(listContents);
+    when(entityTypeClient.getEntityType(entityTypeId, ListActions.READ)).thenReturn(entityType);
+
+    ListContentsFqmRequestException exception = assertThrows(
+      ListContentsFqmRequestException.class,
+      () -> listService.getListContents(listId, fields, offset, size)
+    );
+
+    assertThat(exception.getMessage()).contains("Please refresh the list");
+  }
+
+  @Test
+  void shouldThrowInvalidListContentsExceptionWhenQueryClientThrowsFeignServerException() {
+    String tenantId = "tenant_01";
+    UUID entityTypeId = UUID.randomUUID();
+    UUID listId = UUID.randomUUID();
+    List<List<String>> contentIds = List.of(
+      List.of(UUID.randomUUID().toString())
+    );
+
+    List<EntityTypeColumn> columns = List.of(
+      new EntityTypeColumn().name("id").isIdColumn(true).visibleByDefault(true)
+    );
+    EntityType entityType = new EntityType().name("entity-type").columns(columns);
+
+    int offset = 0;
+    int size = 1;
+    int contentVersion = 2;
+    List<String> fields = List.of("id");
+    ContentsRequest contentsRequest = new ContentsRequest().entityTypeId(entityTypeId)
+      .fields(fields)
+      .ids(contentIds);
+
+    List<ListContent> listContents = contentIds.stream()
+      .map(id -> new ListContent().withContentId(id))
+      .toList();
+
+    ListRefreshDetails successRefresh = ListRefreshDetails.builder().contentVersion(contentVersion).recordsCount(1).build();
+    ListEntity listEntity = new ListEntity()
+      .withSuccessRefresh(successRefresh)
+      .withEntityTypeId(entityTypeId)
+      .withId(listId)
+      .withFields(fields);
+
+    // Mock a FeignServerException to be thrown by queryClient
+    FeignException.FeignServerException feignException = mock(FeignException.FeignServerException.class);
+
+    when(executionContext.getTenantId()).thenReturn(tenantId);
+    when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(listEntity));
+    when(listContentsRepository.getContents(listId, successRefresh.getId(), new OffsetRequest(offset, size))).thenReturn(listContents);
+    when(entityTypeClient.getEntityType(entityTypeId, ListActions.READ)).thenReturn(entityType);
+    when(queryClient.getContents(contentsRequest)).thenThrow(feignException);
+
+    ListContentsFqmRequestException exception = assertThrows(
+      ListContentsFqmRequestException.class,
+      () -> listService.getListContents(listId, fields, offset, size)
+    );
+
+    assertThat(exception.getMessage()).contains("Failed to retrieve list contents");
+  }
+
+  @Test
+  void shouldHandleEmptyContentIdsCorrectlyWithMultipleIdColumns() {
+    String tenantId = "tenant_01";
+    UUID entityTypeId = UUID.randomUUID();
+    UUID listId = UUID.randomUUID();
+
+    // Empty content IDs list
+    List<List<String>> contentIds = List.of();
+
+    // Entity type with multiple ID columns
+    List<EntityTypeColumn> columns = List.of(
+      new EntityTypeColumn().name("id").isIdColumn(true).visibleByDefault(true),
+      new EntityTypeColumn().name("secondary_id").isIdColumn(true).visibleByDefault(true)
+    );
+    EntityType entityType = new EntityType().name("entity-type").columns(columns);
+
+    int offset = 0;
+    int size = 1;
+    int contentVersion = 2;
+    List<String> fields = List.of("id", "secondary_id");
+    ContentsRequest contentsRequest = new ContentsRequest().entityTypeId(entityTypeId)
+      .fields(fields)
+      .ids(contentIds);
+
+    List<ListContent> listContents = List.of(); // Empty list contents
+
+    ListRefreshDetails successRefresh = ListRefreshDetails.builder().contentVersion(contentVersion).recordsCount(0).build();
+    ListEntity listEntity = new ListEntity()
+      .withSuccessRefresh(successRefresh)
+      .withEntityTypeId(entityTypeId)
+      .withId(listId)
+      .withFields(fields);
+
+    when(executionContext.getTenantId()).thenReturn(tenantId);
+    when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(listEntity));
+    when(listContentsRepository.getContents(listId, successRefresh.getId(), new OffsetRequest(offset, size))).thenReturn(listContents);
+    when(entityTypeClient.getEntityType(entityTypeId, ListActions.READ)).thenReturn(entityType);
+    when(queryClient.getContents(contentsRequest)).thenReturn(List.of());
+
+    Optional<ResultsetPage> result = listService.getListContents(listId, fields, offset, size);
+
+    assertThat(result).isPresent();
+    assertThat(result.get().getContent()).isEmpty();
+    assertThat(result.get().getTotalRecords()).isZero();
+  }
+
+  @Test
+  void shouldValidateContentIdSizeAgainstMultipleIdColumns() {
+    String tenantId = "tenant_01";
+    UUID entityTypeId = UUID.randomUUID();
+    UUID listId = UUID.randomUUID();
+
+    // Content IDs with only 1 ID but entity type expects 2
+    List<List<String>> contentIds = List.of(
+      List.of(UUID.randomUUID().toString()) // Only 1 ID
+    );
+
+    // Entity type expects 2 ID columns
+    List<EntityTypeColumn> columns = List.of(
+      new EntityTypeColumn().name("id").isIdColumn(true).visibleByDefault(true),
+      new EntityTypeColumn().name("secondary_id").isIdColumn(true).visibleByDefault(true)
+    );
+    EntityType entityType = new EntityType().name("entity-type").columns(columns);
+
+    int offset = 0;
+    int size = 1;
+    int contentVersion = 2;
+    List<String> fields = List.of("id", "secondary_id");
+
+    List<ListContent> listContents = contentIds.stream()
+      .map(id -> new ListContent().withContentId(id))
+      .toList();
+
+    ListRefreshDetails successRefresh = ListRefreshDetails.builder().contentVersion(contentVersion).recordsCount(1).build();
+    ListEntity listEntity = new ListEntity()
+      .withSuccessRefresh(successRefresh)
+      .withEntityTypeId(entityTypeId)
+      .withId(listId)
+      .withFields(fields);
+
+    when(executionContext.getTenantId()).thenReturn(tenantId);
+    when(listRepository.findByIdAndIsDeletedFalse(listId)).thenReturn(Optional.of(listEntity));
+    when(listContentsRepository.getContents(listId, successRefresh.getId(), new OffsetRequest(offset, size))).thenReturn(listContents);
+    when(entityTypeClient.getEntityType(entityTypeId, ListActions.READ)).thenReturn(entityType);
+
+    ListContentsFqmRequestException exception = assertThrows(
+      ListContentsFqmRequestException.class,
+      () -> listService.getListContents(listId, fields, offset, size)
+    );
+
+    assertThat(exception.getMessage()).contains("Failed to retrieve list contents");
   }
 }


### PR DESCRIPTION
This scenario can happen easily with custom entity types, as users can freely make breaking changes to their own ETs. Fortunately, the solution is generally simple: refresh the list to get new content IDs
