### PR TITLE
MODLISTS-223 Update list content retrieval error handling

### DIFF
--- a/src/main/java/org/folio/list/exception/ListContentsFqmRequestException.java
+++ b/src/main/java/org/folio/list/exception/ListContentsFqmRequestException.java
@@ -6,6 +6,9 @@ import org.springframework.http.HttpStatus;
 
 public class ListContentsFqmRequestException extends SimpleListException {
   public ListContentsFqmRequestException(ListEntity list) {
-    super(list, ListActions.READ, "Failed to retrieve list contents for list " + list.getId() + ". This may be due to an upstream data schema change. Please refresh the list.", "list.contents.request.failed", HttpStatus.CONFLICT);
+    this(list, "This may be due to an upstream data schema change, in which case, refreshing the list may be sufficient to fix the issue.");
+  }
+  public ListContentsFqmRequestException(ListEntity list, String message) {
+    super(list, ListActions.READ, "Failed to retrieve list contents for list " + list.getId() + ". " + message, "list.contents.request.failed", HttpStatus.CONFLICT);
   }
 }

--- a/src/test/java/org/folio/list/service/ListServiceGetListContentsTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceGetListContentsTest.java
@@ -226,7 +226,7 @@ class ListServiceGetListContentsTest {
       () -> listService.getListContents(listId, fields, offset, size)
     );
 
-    assertThat(exception.getMessage()).contains("Please refresh the list");
+    assertThat(exception.getMessage()).startsWith("Failed to retrieve list contents");
   }
 
   @Test


### PR DESCRIPTION
This commit updates how the module handles error encountered when retrieving list contents. It adds special handling for entity types with no ID columns and updates the wording on error messages, to make it a bit clearer what it going on and when the user can actually do something about it.