### PR TITLE
Temporarily add config permissions back to system user

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -225,6 +225,7 @@
         "circulation-storage.loan-policies.collection.get",
         "circulation.loans.collection.get",
         "comments.collection.get",
+        "configuration.entries.collection.get",
         "departments.collection.get",
         "feefineactions.collection.get",
         "feefines.collection.get",

--- a/src/main/resources/system-user-permissions.txt
+++ b/src/main/resources/system-user-permissions.txt
@@ -74,3 +74,4 @@ waives.collection.get
 inventory-storage.instance-note-types.collection.get
 inventory-storage.holdings-note-types.collection.get
 inventory-storage.electronic-access-relationships.collection.get
+configuration.entries.collection.get


### PR DESCRIPTION
## Purpose
Add back config perm back to system user. I removed it prematurely, since it's still necessary until [MODFQMMGR-746](https://folio-org.atlassian.net/browse/MODFQMMGR-746) is completed