### PR TITLE
Provide includeAll option for entity type retrieval (required for [MODFQMMGR-914])

### DIFF
--- a/src/main/java/org/folio/list/controller/ListController.java
+++ b/src/main/java/org/folio/list/controller/ListController.java
@@ -37,6 +37,7 @@ public class ListController implements ListApi {
                                                            Boolean active,
                                                            Boolean isPrivate, // Note: query param name is "private"
                                                            Boolean includeDeleted,
+                                                           Boolean includePrivateEntityTypes,
                                                            String updatedAsOf
   ) {
     OffsetDateTime providedTimestamp;
@@ -52,6 +53,7 @@ public class ListController implements ListApi {
         active,
         isPrivate,
         Boolean.TRUE.equals(includeDeleted),
+        Boolean.TRUE.equals(includePrivateEntityTypes),
         providedTimestamp
       )
     );

--- a/src/main/java/org/folio/list/rest/EntityTypeClient.java
+++ b/src/main/java/org/folio/list/rest/EntityTypeClient.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 @FeignClient(name = "entity-types")
 public interface EntityTypeClient {
   @GetMapping("")
-  EntityTypeSummaryResponse getEntityTypeSummary(@RequestParam List<UUID> ids, boolean includeAll);
+  EntityTypeSummaryResponse getEntityTypeSummary(@RequestParam List<UUID> ids, @RequestParam boolean includeAll);
 
   @GetMapping("/{entityTypeId}")
   EntityType getEntityType(@RequestHeader UUID entityTypeId);

--- a/src/main/java/org/folio/list/rest/EntityTypeClient.java
+++ b/src/main/java/org/folio/list/rest/EntityTypeClient.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 @FeignClient(name = "entity-types")
 public interface EntityTypeClient {
   @GetMapping("")
-  EntityTypeSummaryResponse getEntityTypeSummary(@RequestParam List<UUID> ids);
+  EntityTypeSummaryResponse getEntityTypeSummary(@RequestParam List<UUID> ids, boolean includeAll);
 
   @GetMapping("/{entityTypeId}")
   EntityType getEntityType(@RequestHeader UUID entityTypeId);

--- a/src/main/java/org/folio/list/services/ListService.java
+++ b/src/main/java/org/folio/list/services/ListService.java
@@ -78,8 +78,10 @@ public class ListService {
   private final RefreshFailedCallback refreshFailedCallback;
   private final UsersClient usersClient;
 
+  @SuppressWarnings("java:S107")
   public ListSummaryResultsDTO getAllLists(Pageable pageable, List<UUID> ids, List<UUID> entityTypeIds, Boolean active,
-                                           Boolean isPrivate, boolean includeDeleted, boolean includePrivateEntityTypes, OffsetDateTime updatedAsOf) {
+                                           Boolean isPrivate, boolean includeDeleted, boolean includePrivateEntityTypes,
+                                           OffsetDateTime updatedAsOf) {
 
     log.info("Attempting to get all lists");
 

--- a/src/main/java/org/folio/list/services/ListService.java
+++ b/src/main/java/org/folio/list/services/ListService.java
@@ -79,11 +79,11 @@ public class ListService {
   private final UsersClient usersClient;
 
   public ListSummaryResultsDTO getAllLists(Pageable pageable, List<UUID> ids, List<UUID> entityTypeIds, Boolean active,
-                                           Boolean isPrivate, boolean includeDeleted, OffsetDateTime updatedAsOf) {
+                                           Boolean isPrivate, boolean includeDeleted, boolean includePrivateEntityTypes, OffsetDateTime updatedAsOf) {
 
     log.info("Attempting to get all lists");
 
-    EntityTypeSummaryResponse entityTypeSummaryResponse = entityTypeClient.getEntityTypeSummary(null, false);
+    EntityTypeSummaryResponse entityTypeSummaryResponse = entityTypeClient.getEntityTypeSummary(null, includePrivateEntityTypes);
 
     migrationService.verifyListsAreUpToDate(entityTypeSummaryResponse._version());
 

--- a/src/main/java/org/folio/list/services/ListService.java
+++ b/src/main/java/org/folio/list/services/ListService.java
@@ -83,7 +83,7 @@ public class ListService {
 
     log.info("Attempting to get all lists");
 
-    EntityTypeSummaryResponse entityTypeSummaryResponse = entityTypeClient.getEntityTypeSummary(null);
+    EntityTypeSummaryResponse entityTypeSummaryResponse = entityTypeClient.getEntityTypeSummary(null, false);
 
     migrationService.verifyListsAreUpToDate(entityTypeSummaryResponse._version());
 

--- a/src/main/java/org/folio/list/services/MigrationService.java
+++ b/src/main/java/org/folio/list/services/MigrationService.java
@@ -150,7 +150,7 @@ public class MigrationService {
     log.info("Migrating cross-tenant lists to private, to cover cases in MODLISTS-152");
 
     List<EntityTypeSummary> crossTenantEntityTypes = systemUserScopedExecutionService
-      .executeSystemUserScoped(() -> entityTypeClient.getEntityTypeSummary(null))
+      .executeSystemUserScoped(() -> entityTypeClient.getEntityTypeSummary(null, false))
       .entityTypes()
       .stream()
       .filter(EntityTypeSummary::crossTenantQueriesEnabled)

--- a/src/main/resources/swagger.api/list.yaml
+++ b/src/main/resources/swagger.api/list.yaml
@@ -63,6 +63,12 @@ paths:
           required: false
           schema:
             type: boolean
+        - name: includePrivateEntityTypes
+          in: query
+          description: Indicates if lists for private entity types should be included in the results (default false)
+          required: false
+          schema:
+            type: boolean
         - name: updatedAsOf
           in: query
           description: Indicates the minimum create/update timestamp to filter lists by

--- a/src/test/java/org/folio/list/controller/ListControllerGetListsTest.java
+++ b/src/test/java/org/folio/list/controller/ListControllerGetListsTest.java
@@ -57,7 +57,7 @@ class ListControllerGetListsTest {
       .header(XOkapiHeaders.TENANT, TENANT_ID);
 
     when(listService.getAllLists(any(Pageable.class), isNull(), isNull(),
-     isNull(), isNull(), eq(false), isNull())).thenReturn(listSummaryResultsDto);
+     isNull(), isNull(), eq(false), eq(false), isNull())).thenReturn(listSummaryResultsDto);
 
     mockMvc.perform(requestBuilder)
       .andExpect(status().isOk())
@@ -94,7 +94,7 @@ class ListControllerGetListsTest {
 
 
     when(listService.getAllLists(any(Pageable.class), Mockito.eq(listIds),
-      Mockito.eq(listEntityIds), Mockito.eq(true), Mockito.eq(true), Mockito.eq(false), Mockito.eq(providedTimestamp)))
+      Mockito.eq(listEntityIds), Mockito.eq(true), Mockito.eq(true), Mockito.eq(false), eq(false), Mockito.eq(providedTimestamp)))
       .thenReturn(listSummaryResultsDto);
 
     mockMvc.perform(requestBuilder)
@@ -130,7 +130,7 @@ class ListControllerGetListsTest {
       .queryParam("private", "false");
 
     when(listService.getAllLists(pageable, null,
-      null, false, false, false, null)).thenReturn(listSummaryResultsDto);
+      null, false, false, false, false, null)).thenReturn(listSummaryResultsDto);
 
     mockMvc.perform(requestBuilder)
       .andExpect(status().isOk())

--- a/src/test/java/org/folio/list/service/ListServiceTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceTest.java
@@ -143,6 +143,7 @@ class ListServiceTest {
       true,
       false,
       false,
+      false,
       null
     );
     assertThat(actual.getContent()).isEqualTo(expected.getContent());
@@ -191,6 +192,7 @@ class ListServiceTest {
       true,
       false,
       false,
+      false,
       null
     );
     assertThat(actual.getContent()).isEqualTo(expected.getContent());
@@ -207,6 +209,7 @@ class ListServiceTest {
       List.of(UUID.randomUUID(), UUID.randomUUID()),
       null,
       true,
+      false,
       false,
       false,
       null

--- a/src/test/java/org/folio/list/service/ListServiceTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceTest.java
@@ -131,7 +131,7 @@ class ListServiceTest {
     )).thenReturn(listEntities);
     when(listSummaryMapper.toListSummaryDTO(entity1, "Item")).thenReturn(listSummaryDto1.entityTypeName("Item"));
     when(listSummaryMapper.toListSummaryDTO(entity2, "Loan")).thenReturn(listSummaryDto2.entityTypeName("Loan"));
-    when(entityTypeClient.getEntityTypeSummary(null))
+    when(entityTypeClient.getEntityTypeSummary(null, false))
       .thenReturn(new EntityTypeSummaryResponse(List.of(expectedSummary1, expectedSummary2, expectedSummary3), "newest and bestest"));
 
     Page<ListSummaryDTO> expected = new PageImpl<>(List.of(listSummaryDto1, listSummaryDto2));
@@ -179,7 +179,7 @@ class ListServiceTest {
     )).thenReturn(listEntities);
     when(listSummaryMapper.toListSummaryDTO(entity1, "Item")).thenReturn(listSummaryDto1.entityTypeName("Item"));
     when(listSummaryMapper.toListSummaryDTO(entity2, "Loan")).thenReturn(listSummaryDto2.entityTypeName("Loan"));
-    when(entityTypeClient.getEntityTypeSummary(null))
+    when(entityTypeClient.getEntityTypeSummary(null, false))
       .thenReturn(new EntityTypeSummaryResponse(List.of(expectedSummary1, expectedSummary2), "newest and bestest"));
 
     Page<ListSummaryDTO> expected = new PageImpl<>(List.of(listSummaryDto1, listSummaryDto2));
@@ -200,7 +200,7 @@ class ListServiceTest {
 
   @Test
   void getAllListsShouldReturnEmptyPageForEmptySearchEntityTypeIds() {
-    when(entityTypeClient.getEntityTypeSummary(null)).thenReturn(new EntityTypeSummaryResponse(List.of(), "newest and bestest"));
+    when(entityTypeClient.getEntityTypeSummary(null, false)).thenReturn(new EntityTypeSummaryResponse(List.of(), "newest and bestest"));
     Page<ListSummaryDTO> expected = new PageImpl<>(List.of());
     var actual = listService.getAllLists(
       Pageable.ofSize(100),

--- a/src/test/java/org/folio/list/service/MigrationServiceTest.java
+++ b/src/test/java/org/folio/list/service/MigrationServiceTest.java
@@ -241,7 +241,7 @@ class MigrationServiceTest {
     ListEntity listToNotUpdate = spy(new ListEntity().withEntityTypeId(nonCrossTenantEntityType));
 
     when(migrationRepository.hasModlists152CrossTenantSetToPrivateMigrationOccurred()).thenReturn(false);
-    when(entityTypeClient.getEntityTypeSummary(null))
+    when(entityTypeClient.getEntityTypeSummary(null, false))
       .thenReturn(
         new EntityTypeClient.EntityTypeSummaryResponse(
           List.of(


### PR DESCRIPTION
## Purpose
Provide includeAll option for entity type retrieval (required for [MODFQMMGR-914](https://folio-org.atlassian.net/browse/MODFQMMGR-914))

MODFQMMGR-914 requires us to confirm that no lists are using the given ET prior to deletion. To do so, we need to be able to retrieve private ETs from mod-fqm-manager.
