### PR TITLE
Revert "[MODFQMMGR-971] Add Linked Data permissions (#236)"

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -279,7 +279,6 @@
         "inventory-storage.subject-types.collection.get",
         "invoice.invoice-lines.collection.get",
         "invoice.invoices.collection.get",
-        "linked-data.resources.rdf.get",
         "lost-item-fees-policies.collection.get",
         "manual-block-templates.collection.get",
         "manualblocks.collection.get",

--- a/src/main/resources/system-user-permissions.txt
+++ b/src/main/resources/system-user-permissions.txt
@@ -59,7 +59,6 @@ inventory-storage.subject-sources.collection.get
 inventory-storage.subject-types.collection.get
 invoice.invoice-lines.collection.get
 invoice.invoices.collection.get
-linked-data.resources.rdf.get
 lost-item-fees-policies.collection.get
 manual-block-templates.collection.get
 manualblocks.collection.get


### PR DESCRIPTION
Reverting https://github.com/folio-org/mod-lists/pull/236 as it caused failure in deploying FOLIO

## Purpose
Reverting https://github.com/folio-org/mod-lists/pull/236 as it caused failure in deploying FOLIO

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
