### PR TITLE
[MODLISTS-265] Propagate accept-language header during export

### DIFF
--- a/src/main/java/org/folio/list/services/RunAsSystemUserService.java
+++ b/src/main/java/org/folio/list/services/RunAsSystemUserService.java
@@ -69,9 +69,10 @@ public class RunAsSystemUserService {
   }
 
   private void copyAcceptLanguageHeader(Map<String, Collection<String>> headers) {
-    outerContext.getAllHeaders().entrySet().stream()
-      .filter(entry -> HttpHeaders.ACCEPT_LANGUAGE.equalsIgnoreCase(entry.getKey()))
-      .findFirst()
-      .ifPresent(entry -> headers.put(HttpHeaders.ACCEPT_LANGUAGE, List.copyOf(entry.getValue())));
+    outerContext.getAllHeaders().forEach((key, value) -> {
+      if (HttpHeaders.ACCEPT_LANGUAGE.equalsIgnoreCase(key) && value != null) {
+        headers.put(HttpHeaders.ACCEPT_LANGUAGE, List.copyOf(value));
+      }
+    });
   }
 }

--- a/src/main/java/org/folio/list/services/RunAsSystemUserService.java
+++ b/src/main/java/org/folio/list/services/RunAsSystemUserService.java
@@ -4,9 +4,13 @@ import org.folio.spring.DefaultFolioExecutionContext;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.integration.XOkapiHeaders;
 import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -15,7 +19,7 @@ import java.util.function.Supplier;
 import lombok.AllArgsConstructor;
 
 /**
- * Runs code in an execution context using the current tenantId with no other headers,
+ * Runs code in an execution context using the current tenantId with only safe non-auth headers,
  * simulating a system user's context. Eureka uses a lack of token/etc from us here to
  * determine that things are running as a system user and will inject the token/etc at
  * the routing level.
@@ -53,12 +57,21 @@ public class RunAsSystemUserService {
   }
 
   private FolioExecutionContext systemUserExecutionContext(String tenantId) {
+    Map<String, Collection<String>> headers = new HashMap<>();
+    headers.put(XOkapiHeaders.URL, Collections.singleton(outerContext.getOkapiUrl()));
+    headers.put(XOkapiHeaders.TENANT, Collections.singleton(tenantId));
+    copyAcceptLanguageHeader(headers);
+
     return new DefaultFolioExecutionContext(
       outerContext.getFolioModuleMetadata(),
-      Map.ofEntries(
-        Map.entry(XOkapiHeaders.URL, Collections.singleton(outerContext.getOkapiUrl())),
-        Map.entry(XOkapiHeaders.TENANT, Collections.singleton(tenantId))
-      )
+      headers
     );
+  }
+
+  private void copyAcceptLanguageHeader(Map<String, Collection<String>> headers) {
+    outerContext.getAllHeaders().entrySet().stream()
+      .filter(entry -> HttpHeaders.ACCEPT_LANGUAGE.equalsIgnoreCase(entry.getKey()))
+      .findFirst()
+      .ifPresent(entry -> headers.put(HttpHeaders.ACCEPT_LANGUAGE, List.copyOf(entry.getValue())));
   }
 }

--- a/src/main/java/org/folio/list/services/RunAsSystemUserService.java
+++ b/src/main/java/org/folio/list/services/RunAsSystemUserService.java
@@ -70,7 +70,7 @@ public class RunAsSystemUserService {
 
   private void copyAcceptLanguageHeader(Map<String, Collection<String>> headers) {
     outerContext.getAllHeaders().forEach((key, value) -> {
-      if (HttpHeaders.ACCEPT_LANGUAGE.equalsIgnoreCase(key) && value != null) {
+      if (HttpHeaders.ACCEPT_LANGUAGE.equalsIgnoreCase(key)) {
         headers.put(HttpHeaders.ACCEPT_LANGUAGE, List.copyOf(value));
       }
     });

--- a/src/test/java/org/folio/list/service/ListServiceTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceTest.java
@@ -47,9 +47,9 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;

--- a/src/test/java/org/folio/list/service/RunAsSystemUserServiceTest.java
+++ b/src/test/java/org/folio/list/service/RunAsSystemUserServiceTest.java
@@ -1,8 +1,10 @@
 package org.folio.list.service;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import lombok.extern.log4j.Log4j2;
 import org.folio.list.context.TestcontainerCallbackExtension;
@@ -31,21 +33,32 @@ class RunAsSystemUserServiceTest {
   private static final String MODULE_NAME = "our-module";
   private static final String ACCEPT_LANGUAGE = "de-DE-u-nu-latn";
 
-  private static final FolioExecutionContext REGULAR_EXECUTION_CONTEXT = new DefaultFolioExecutionContext(
-    new FolioModuleMetadata() {
-      public String getModuleName() {
-        return MODULE_NAME;
-      }
+  private static final FolioModuleMetadata MODULE_METADATA = new FolioModuleMetadata() {
+    public String getModuleName() {
+      return MODULE_NAME;
+    }
 
-      public String getDBSchemaName(String t) {
-        return t + "_schema";
-      }
-    },
+    public String getDBSchemaName(String t) {
+      return t + "_schema";
+    }
+  };
+
+  private static final FolioExecutionContext REGULAR_EXECUTION_CONTEXT = new DefaultFolioExecutionContext(
+    MODULE_METADATA,
     Map.ofEntries(
       Map.entry(XOkapiHeaders.TENANT, Collections.singleton(TENANT_ID)),
       Map.entry(XOkapiHeaders.TOKEN, Collections.singleton(TOKEN)),
       Map.entry(XOkapiHeaders.URL, Collections.singleton(OKAPI_URL)),
       Map.entry(HttpHeaders.ACCEPT_LANGUAGE, Collections.singleton(ACCEPT_LANGUAGE))
+    )
+  );
+
+  private static final FolioExecutionContext NO_ACCEPT_LANGUAGE_CONTEXT = new DefaultFolioExecutionContext(
+    MODULE_METADATA,
+    Map.ofEntries(
+      Map.entry(XOkapiHeaders.TENANT, Collections.singleton(TENANT_ID)),
+      Map.entry(XOkapiHeaders.TOKEN, Collections.singleton(TOKEN)),
+      Map.entry(XOkapiHeaders.URL, Collections.singleton(OKAPI_URL))
     )
   );
 
@@ -97,6 +110,20 @@ class RunAsSystemUserServiceTest {
     });
   }
 
+  @Test
+  void doesNotPropagateAcceptLanguageWhenAbsent() {
+    NO_ACCEPT_LANGUAGE_CONTEXT.execute(() ->
+      runAsSystemUserService.executeSystemUserScoped(
+        INNER_TENANT_ID,
+        () -> {
+          assertEquals(INNER_TENANT_ID, folioExecutionContext.getTenantId());
+          assertNull(folioExecutionContext.getAllHeaders().get(HttpHeaders.ACCEPT_LANGUAGE));
+          return null;
+        }
+      )
+    );
+  }
+
   private void verifyRegularContext() {
     assertEquals(OKAPI_URL, folioExecutionContext.getOkapiUrl());
     assertEquals(MODULE_NAME, folioExecutionContext.getFolioModuleMetadata().getModuleName());
@@ -113,7 +140,7 @@ class RunAsSystemUserServiceTest {
     assertEquals(MODULE_NAME, folioExecutionContext.getFolioModuleMetadata().getModuleName());
     assertEquals(INNER_TENANT_ID, folioExecutionContext.getTenantId());
     assertEquals(
-      Collections.singleton(ACCEPT_LANGUAGE),
+      List.of(ACCEPT_LANGUAGE),
       folioExecutionContext.getAllHeaders().get(HttpHeaders.ACCEPT_LANGUAGE)
     );
     assertEquals("", folioExecutionContext.getToken());

--- a/src/test/java/org/folio/list/service/RunAsSystemUserServiceTest.java
+++ b/src/test/java/org/folio/list/service/RunAsSystemUserServiceTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.ActiveProfiles;
 
 @Log4j2
@@ -28,6 +29,7 @@ class RunAsSystemUserServiceTest {
   private static final String TOKEN = "token";
   private static final String OKAPI_URL = "test_url";
   private static final String MODULE_NAME = "our-module";
+  private static final String ACCEPT_LANGUAGE = "de-DE-u-nu-latn";
 
   private static final FolioExecutionContext REGULAR_EXECUTION_CONTEXT = new DefaultFolioExecutionContext(
     new FolioModuleMetadata() {
@@ -42,7 +44,8 @@ class RunAsSystemUserServiceTest {
     Map.ofEntries(
       Map.entry(XOkapiHeaders.TENANT, Collections.singleton(TENANT_ID)),
       Map.entry(XOkapiHeaders.TOKEN, Collections.singleton(TOKEN)),
-      Map.entry(XOkapiHeaders.URL, Collections.singleton(OKAPI_URL))
+      Map.entry(XOkapiHeaders.URL, Collections.singleton(OKAPI_URL)),
+      Map.entry(HttpHeaders.ACCEPT_LANGUAGE, Collections.singleton(ACCEPT_LANGUAGE))
     )
   );
 
@@ -99,12 +102,20 @@ class RunAsSystemUserServiceTest {
     assertEquals(MODULE_NAME, folioExecutionContext.getFolioModuleMetadata().getModuleName());
     assertEquals(TENANT_ID, folioExecutionContext.getTenantId());
     assertEquals(TOKEN, folioExecutionContext.getToken());
+    assertEquals(
+      Collections.singleton(ACCEPT_LANGUAGE),
+      folioExecutionContext.getAllHeaders().get(HttpHeaders.ACCEPT_LANGUAGE)
+    );
   }
 
   private void verifySystemUserContext() {
     assertEquals(OKAPI_URL, folioExecutionContext.getOkapiUrl());
     assertEquals(MODULE_NAME, folioExecutionContext.getFolioModuleMetadata().getModuleName());
     assertEquals(INNER_TENANT_ID, folioExecutionContext.getTenantId());
+    assertEquals(
+      Collections.singleton(ACCEPT_LANGUAGE),
+      folioExecutionContext.getAllHeaders().get(HttpHeaders.ACCEPT_LANGUAGE)
+    );
     assertEquals("", folioExecutionContext.getToken());
   }
 }

--- a/src/test/java/org/folio/list/service/RunAsSystemUserServiceTest.java
+++ b/src/test/java/org/folio/list/service/RunAsSystemUserServiceTest.java
@@ -1,7 +1,7 @@
 package org.folio.list.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
## Purpose
[MODLISTS-265](https://folio-org.atlassian.net/browse/MODLISTS-265): Propagate accept-language header during export

## Approach
Propagate accept-language header so that mod-fqm-manager localizes language codes according to the user's locale.
