### PR TITLE
MODLISTS-243 Add support for filtering lists by is_canned

### DIFF
--- a/src/main/java/org/folio/list/controller/ListController.java
+++ b/src/main/java/org/folio/list/controller/ListController.java
@@ -41,6 +41,7 @@ public class ListController implements ListApi {
     Optional<String> search,
     Optional<Boolean> active,
     Optional<Boolean> isPrivate, // Note: query param name is "private"
+    Optional<Boolean> canned,
     Optional<Boolean> includeDeleted,
     Optional<String> updatedAsOf,
     Optional<String> sortBy,
@@ -61,6 +62,7 @@ public class ListController implements ListApi {
         entityTypeIds.orElse(null),
         active.orElse(null),
         isPrivate.orElse(null),
+        canned.orElse(null),
         Boolean.TRUE.equals(includeDeleted.orElse(null)),
         providedTimestamp,
         search.orElse(null)

--- a/src/main/java/org/folio/list/repository/ListRepository.java
+++ b/src/main/java/org/folio/list/repository/ListRepository.java
@@ -26,6 +26,7 @@ public interface ListRepository extends CrudRepository<ListEntity, UUID>, Paging
       AND (COALESCE(:entityTypeIds) IS NULL OR l.entityTypeId IN (:entityTypeIds))
       AND (l.isPrivate = false OR l.updatedBy = :currentUserId OR ( l.updatedBy IS NULL AND l.createdBy = :currentUserId))
       AND (:isPrivate IS NULL OR l.isPrivate = :isPrivate)
+      AND (:canned IS NULL OR l.isCanned = :canned)
       AND (:active IS NULL OR l.isActive = :active)
       AND (:includeDeleted = true OR l.isDeleted = false)
       AND (TO_TIMESTAMP(CAST(:updatedAsOf AS text), 'YYYY-MM-DD HH24:MI:SS.MS') IS NULL OR
@@ -42,6 +43,7 @@ public interface ListRepository extends CrudRepository<ListEntity, UUID>, Paging
       AND (COALESCE(:entityTypeIds) IS NULL OR l.entityTypeId IN (:entityTypeIds))
       AND (l.isPrivate = false OR l.updatedBy = :currentUserId OR ( l.updatedBy IS NULL AND l.createdBy = :currentUserId))
       AND (:isPrivate IS NULL OR l.isPrivate = :isPrivate)
+      AND (:canned IS NULL OR l.isCanned = :canned)
       AND (:active IS NULL OR l.isActive = :active)
       AND (:includeDeleted = true OR l.isDeleted = false)
       AND (TO_TIMESTAMP(CAST(:updatedAsOf AS text), 'YYYY-MM-DD HH24:MI:SS.MS') IS NULL OR
@@ -59,6 +61,7 @@ public interface ListRepository extends CrudRepository<ListEntity, UUID>, Paging
     UUID currentUserId,
     Boolean active,
     Boolean isPrivate,
+    Boolean canned,
     boolean includeDeleted,
     OffsetDateTime updatedAsOf,
     String searchPattern

--- a/src/main/java/org/folio/list/services/ListService.java
+++ b/src/main/java/org/folio/list/services/ListService.java
@@ -83,7 +83,7 @@ public class ListService {
   private final UsersClient usersClient;
 
   public ListSummaryResultsDTO getAllLists(Pageable pageable, List<UUID> ids, List<UUID> entityTypeIds, Boolean active,
-                                           Boolean isPrivate, boolean includeDeleted, OffsetDateTime updatedAsOf,
+                                           Boolean isPrivate, Boolean canned, boolean includeDeleted, OffsetDateTime updatedAsOf,
                                            String search) {
 
     log.info("Attempting to get all lists");
@@ -118,6 +118,7 @@ public class ListService {
       currentUserId,
       active,
       isPrivate,
+      canned,
       includeDeleted,
       updatedAsOf,
       searchPattern
@@ -388,6 +389,7 @@ public class ListService {
       null, // currentUserId
       null, // active
       null, // isPrivate
+      null, // canned
       false, // includeDeleted
       null, // updatedAsOf
       null // searchPattern

--- a/src/main/resources/swagger.api/list.yaml
+++ b/src/main/resources/swagger.api/list.yaml
@@ -67,6 +67,12 @@ paths:
           required: false
           schema:
             type: boolean
+        - name: canned
+          in: query
+          description: Indicates whether returned lists should be canned/system generated. When omitted, both canned and non-canned lists are returned.
+          required: false
+          schema:
+            type: boolean
         - name: includeDeleted
           in: query
           description: Indicates if deleted lists should be included in the results (default false)

--- a/src/test/java/org/folio/list/controller/ListControllerGetListsTest.java
+++ b/src/test/java/org/folio/list/controller/ListControllerGetListsTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.data.domain.Pageable;
@@ -31,6 +30,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -64,7 +64,7 @@ class ListControllerGetListsTest {
       .header(XOkapiHeaders.TENANT, TENANT_ID);
 
     when(listService.getAllLists(any(Pageable.class), isNull(), isNull(),
-     isNull(), isNull(), eq(false), isNull(), isNull())).thenReturn(listSummaryResultsDto);
+      isNull(), isNull(), isNull(), eq(false), isNull(), isNull())).thenReturn(listSummaryResultsDto);
 
     mockMvc.perform(requestBuilder)
       .andExpect(status().isOk())
@@ -77,7 +77,7 @@ class ListControllerGetListsTest {
 
     ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
     verify(listService).getAllLists(pageableCaptor.capture(), isNull(), isNull(),
-      isNull(), isNull(), eq(false), isNull(), isNull());
+      isNull(), isNull(), isNull(), eq(false), isNull(), isNull());
     assertSort(pageableCaptor.getValue(), "name", Sort.Direction.ASC);
   }
 
@@ -105,9 +105,9 @@ class ListControllerGetListsTest {
       .queryParam("updatedAsOf", "2023-01-27T20:54:41.528281+05:30");
 
 
-    when(listService.getAllLists(any(Pageable.class), Mockito.eq(listIds),
-      Mockito.eq(listEntityIds), Mockito.eq(true), Mockito.eq(true), Mockito.eq(false), Mockito.eq(providedTimestamp),
-      isNull()))
+    when(listService.getAllLists(any(Pageable.class), eq(listIds),
+      eq(listEntityIds), eq(true), eq(true), isNull(), eq(false),
+      eq(providedTimestamp), isNull()))
       .thenReturn(listSummaryResultsDto);
 
     mockMvc.perform(requestBuilder)
@@ -149,7 +149,7 @@ class ListControllerGetListsTest {
       .queryParam("private", "false");
 
     when(listService.getAllLists(pageable, null,
-      null, false, false, false, null, "missing")).thenReturn(listSummaryResultsDto);
+      null, false, false, null, false, null, "missing")).thenReturn(listSummaryResultsDto);
 
     mockMvc.perform(requestBuilder)
       .andExpect(status().isOk())
@@ -162,10 +162,38 @@ class ListControllerGetListsTest {
 
     ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
     verify(listService).getAllLists(pageableCaptor.capture(), isNull(),
-      isNull(), eq(false), eq(false), eq(false), isNull(), eq("missing"));
+      isNull(), eq(false), eq(false), isNull(), eq(false), isNull(), eq("missing"));
     assertThat(pageableCaptor.getValue().getOffset()).isEqualTo(offset);
     assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(size);
     assertSort(pageableCaptor.getValue(), "successRefresh.recordsCount", Sort.Direction.DESC);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "true",
+    "false"
+  })
+  void testGetAllListsWithCannedParameter(Boolean canned) throws Exception {
+    ListSummaryResultsDTO emptyResults = new ListSummaryResultsDTO()
+      .content(List.of())
+      .totalRecords(0L)
+      .totalPages(0);
+
+    var requestBuilder = get("/lists")
+      .contentType(APPLICATION_JSON)
+      .header(XOkapiHeaders.TENANT, TENANT_ID)
+      .queryParam("canned", canned.toString());
+
+    when(listService.getAllLists(any(Pageable.class), isNull(), isNull(),
+      isNull(), isNull(), eq(canned), eq(false), isNull(), isNull())).thenReturn(emptyResults);
+
+    mockMvc.perform(requestBuilder)
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.totalRecords", is(0)))
+      .andExpect(jsonPath("$.totalPages", is(0)));
+
+    verify(listService).getAllLists(any(Pageable.class), isNull(), isNull(),
+      isNull(), isNull(), eq(canned), eq(false), isNull(), isNull());
   }
 
   @ParameterizedTest
@@ -191,7 +219,7 @@ class ListControllerGetListsTest {
       .queryParam("sortOrder", sortOrder);
 
     when(listService.getAllLists(any(Pageable.class), isNull(), isNull(),
-      isNull(), isNull(), eq(false), isNull(), isNull())).thenReturn(emptyResults);
+      isNull(), isNull(), isNull(), eq(false), isNull(), isNull())).thenReturn(emptyResults);
 
     mockMvc.perform(requestBuilder)
       .andExpect(status().isOk())
@@ -200,7 +228,7 @@ class ListControllerGetListsTest {
 
     ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
     verify(listService).getAllLists(pageableCaptor.capture(), isNull(), isNull(),
-      isNull(), isNull(), eq(false), isNull(), isNull());
+      isNull(), isNull(), isNull(), eq(false), isNull(), isNull());
     assertSort(pageableCaptor.getValue(), expectedProperty, expectedDirection);
   }
 
@@ -218,7 +246,7 @@ class ListControllerGetListsTest {
       .andExpect(jsonPath("$.parameters[0].value", containsString("getAllLists.sortBy")))
       .andExpect(jsonPath("$.parameters[0].value", containsString("name|updatedDate|recordsCount")));
 
-    Mockito.verifyNoInteractions(listService);
+    verifyNoInteractions(listService);
   }
 
   @Test
@@ -235,7 +263,7 @@ class ListControllerGetListsTest {
       .andExpect(jsonPath("$.parameters[0].value", containsString("getAllLists.sortOrder")))
       .andExpect(jsonPath("$.parameters[0].value", containsString("asc|desc")));
 
-    Mockito.verifyNoInteractions(listService);
+    verifyNoInteractions(listService);
   }
 
   private ListSummaryResultsDTO getListSummaryResultsDTO(ListSummaryDTO listDto1, ListSummaryDTO listDto2) {

--- a/src/test/java/org/folio/list/service/ListServiceDeleteListTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceDeleteListTest.java
@@ -61,6 +61,7 @@ class ListServiceDeleteListTest {
       null,
       null,
       null,
+      null,
       false,
       null,
       null
@@ -91,6 +92,7 @@ class ListServiceDeleteListTest {
       null,
       null,
       List.of(entity.getEntityTypeId()),
+      null,
       null,
       null,
       null,

--- a/src/test/java/org/folio/list/service/ListServiceTest.java
+++ b/src/test/java/org/folio/list/service/ListServiceTest.java
@@ -129,6 +129,7 @@ class ListServiceTest {
       any(UUID.class),
       Mockito.eq(true),
       Mockito.eq(false),
+      isNull(),
       Mockito.eq(false),
       any(),
       isNull()
@@ -146,6 +147,7 @@ class ListServiceTest {
       List.of(entity1.getEntityTypeId(), entity2.getEntityTypeId()),
       true,
       false,
+      null,
       false,
       null,
       null
@@ -179,6 +181,7 @@ class ListServiceTest {
       any(UUID.class),
       Mockito.eq(true),
       Mockito.eq(false),
+      isNull(),
       Mockito.eq(false),
       any(),
       isNull()
@@ -196,6 +199,7 @@ class ListServiceTest {
       null,
       true,
       false,
+      null,
       false,
       null,
       null
@@ -215,6 +219,7 @@ class ListServiceTest {
       null,
       true,
       false,
+      null,
       false,
       null,
       null
@@ -245,6 +250,7 @@ class ListServiceTest {
       Mockito.eq(currentUserId),
       isNull(),
       isNull(),
+      isNull(),
       Mockito.eq(false),
       isNull(),
       Mockito.eq("%missing%")
@@ -253,6 +259,7 @@ class ListServiceTest {
 
     var actual = listService.getAllLists(
       Pageable.ofSize(100),
+      null,
       null,
       null,
       null,
@@ -289,6 +296,7 @@ class ListServiceTest {
       Mockito.eq(currentUserId),
       Mockito.eq(true),
       Mockito.eq(false),
+      Mockito.eq(true),
       Mockito.eq(false),
       isNull(),
       Mockito.eq("%missing%")
@@ -301,6 +309,7 @@ class ListServiceTest {
       List.of(entityTypeId2),
       true,
       false,
+      true,
       false,
       null,
       "missing"
@@ -329,6 +338,7 @@ class ListServiceTest {
       Mockito.eq(currentUserId),
       isNull(),
       isNull(),
+      isNull(),
       Mockito.eq(false),
       isNull(),
       Mockito.eq("%missing%")
@@ -336,6 +346,7 @@ class ListServiceTest {
 
     var actual = listService.getAllLists(
       Pageable.ofSize(100),
+      null,
       null,
       null,
       null,
@@ -367,6 +378,7 @@ class ListServiceTest {
       Mockito.eq(currentUserId),
       isNull(),
       isNull(),
+      isNull(),
       Mockito.eq(false),
       isNull(),
       Mockito.eq("%50!%!_off!!%")
@@ -374,6 +386,7 @@ class ListServiceTest {
 
     var actual = listService.getAllLists(
       Pageable.ofSize(100),
+      null,
       null,
       null,
       null,


### PR DESCRIPTION
This commit adds the ability to filter the lists of lists (GET /lists) by a new (optional) `canned` query parameter. When set to `true`, the API will only return "canned" (system-created) lists. When set to `false`, it will return only user-created lists. When omitted, it maintains the normal behavior, where lists are not filtered by this property at all.