### PR TITLE
MODLISTS-68 Make nulls more intuitive when sorting the list of lists

### DIFF
--- a/src/main/java/org/folio/list/controller/ListController.java
+++ b/src/main/java/org/folio/list/controller/ListController.java
@@ -88,7 +88,10 @@ public class ListController implements ListApi {
       .map(sortableProperties::get)
       .orElse("name");
 
-    return Sort.by(new Sort.Order(direction, property).nullsLast());
+    Sort.Order order = direction == Sort.Direction.DESC
+      ? new Sort.Order(direction, property).nullsLast()
+      : new Sort.Order(direction, property).nullsFirst();
+    return Sort.by(order);
   }
 
   @Override

--- a/src/test/java/org/folio/list/controller/ListControllerGetListsTest.java
+++ b/src/test/java/org/folio/list/controller/ListControllerGetListsTest.java
@@ -278,6 +278,9 @@ class ListControllerGetListsTest {
     Sort.Order order = pageable.getSort().iterator().next();
     assertThat(order.getProperty()).isEqualTo(expectedProperty);
     assertThat(order.getDirection()).isEqualTo(expectedDirection);
-    assertThat(order.getNullHandling()).isEqualTo(Sort.NullHandling.NULLS_LAST);
+    Sort.NullHandling expectedNullHandling = expectedDirection == Sort.Direction.DESC
+      ? Sort.NullHandling.NULLS_LAST
+      : Sort.NullHandling.NULLS_FIRST;
+    assertThat(order.getNullHandling()).isEqualTo(expectedNullHandling);
   }
 }


### PR DESCRIPTION
This commit changes how nulls are handled when sorting the list of lists, so that null values are effectively less than 0 (so they come first in ascending order and last in descending order)
